### PR TITLE
docs: add local development setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,39 @@ make test
 make lint
 ```
 
+### Local Development
+
+1. Create a local Kubernetes cluster with kind or minikube and make sure `kubectl` points to it.
+2. Install the CRDs:
+
+```bash
+make install
+```
+
+3. Run the operator locally against your cluster:
+
+```bash
+make run
+```
+
+4. In a separate shell, apply a sample resource to verify reconciliation works:
+
+```bash
+kubectl apply -f config/samples/
+```
+
+For controller tests, install `setup-envtest` and ensure it is on your `PATH`, then run:
+
+```bash
+make test
+```
+
+To work on the IPC Bus locally, build it with:
+
+```bash
+make build-ipcbus
+```
+
 ## Making Changes
 
 ### Workflow


### PR DESCRIPTION
## What

Adds a local development section to `CONTRIBUTING.md` covering the basic local cluster flow, CRD install, local operator run, sample apply step, controller test note, and IPC bus build command.

## Why

Fixes #5

## How

- documented local cluster prerequisite (`kind`/`minikube`)
- added `make install`
- added `make run`
- added sample apply step with `kubectl apply -f config/samples/`
- documented the `setup-envtest` requirement for controller tests
- added `make build-ipcbus`

## Checklist

- [ ] Tests added/updated
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Generated files up to date (`make generate && make manifests`)
- [x] Documentation updated
- [x] Commits signed off (`git commit -s`)