### PR TITLE
fix: add credential validation to ZeroClaw and PicoClaw adapters

### DIFF
--- a/internal/runtime/picoclaw.go
+++ b/internal/runtime/picoclaw.go
@@ -71,10 +71,19 @@ func (a *PicoClawAdapter) GracefulShutdownSeconds() int32 {
 	return 2
 }
 
-func (a *PicoClawAdapter) Validate(_ context.Context, _ *v1alpha1.ClawSpec) field.ErrorList {
-	return nil
+func (a *PicoClawAdapter) Validate(_ context.Context, spec *v1alpha1.ClawSpec) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if !hasCredentials(spec) {
+		allErrs = append(allErrs, field.Required(
+			field.NewPath("spec", "credentials"),
+			"PicoClaw requires credentials (secretRef, externalSecret, or keys)",
+		))
+	}
+
+	return allErrs
 }
 
-func (a *PicoClawAdapter) ValidateUpdate(_ context.Context, _, _ *v1alpha1.ClawSpec) field.ErrorList {
-	return nil
+func (a *PicoClawAdapter) ValidateUpdate(_ context.Context, oldSpec, newSpec *v1alpha1.ClawSpec) field.ErrorList {
+	return validatePersistenceUpdate(oldSpec, newSpec)
 }

--- a/internal/runtime/picoclaw.go
+++ b/internal/runtime/picoclaw.go
@@ -71,17 +71,9 @@ func (a *PicoClawAdapter) GracefulShutdownSeconds() int32 {
 	return 2
 }
 
-func (a *PicoClawAdapter) Validate(_ context.Context, spec *v1alpha1.ClawSpec) field.ErrorList {
-	var allErrs field.ErrorList
-
-	if !hasCredentials(spec) {
-		allErrs = append(allErrs, field.Required(
-			field.NewPath("spec", "credentials"),
-			"PicoClaw requires credentials (secretRef, externalSecret, or keys)",
-		))
-	}
-
-	return allErrs
+func (a *PicoClawAdapter) Validate(_ context.Context, _ *v1alpha1.ClawSpec) field.ErrorList {
+	// PicoClaw supports non-LLM workloads; credentials are optional.
+	return nil
 }
 
 func (a *PicoClawAdapter) ValidateUpdate(_ context.Context, oldSpec, newSpec *v1alpha1.ClawSpec) field.ErrorList {

--- a/internal/runtime/picoclaw_test.go
+++ b/internal/runtime/picoclaw_test.go
@@ -1,0 +1,202 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Prismer-AI/k8s4claw/api/v1alpha1"
+)
+
+func TestPicoClawValidate_RequiresCredentials(t *testing.T) {
+	t.Parallel()
+	a := &PicoClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{Runtime: v1alpha1.RuntimePicoClaw}
+	errs := a.Validate(ctx, spec)
+	if len(errs) == 0 {
+		t.Fatal("expected error when credentials are missing")
+	}
+	if errs[0].Field != "spec.credentials" {
+		t.Errorf("field = %q; want spec.credentials", errs[0].Field)
+	}
+}
+
+func TestPicoClawValidate_AcceptsSecretRef(t *testing.T) {
+	t.Parallel()
+	a := &PicoClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimePicoClaw,
+		Credentials: &v1alpha1.CredentialSpec{
+			SecretRef: &corev1.LocalObjectReference{Name: "my-secret"},
+		},
+	}
+	errs := a.Validate(ctx, spec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestPicoClawValidate_AcceptsExternalSecret(t *testing.T) {
+	t.Parallel()
+	a := &PicoClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimePicoClaw,
+		Credentials: &v1alpha1.CredentialSpec{
+			ExternalSecret: &v1alpha1.ExternalSecretRef{
+				Provider: "vault",
+				Store:    "main",
+				Path:     "secret/picoclaw",
+			},
+		},
+	}
+	errs := a.Validate(ctx, spec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestPicoClawValidate_AcceptsKeyMappingsOnly(t *testing.T) {
+	t.Parallel()
+	a := &PicoClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimePicoClaw,
+		Credentials: &v1alpha1.CredentialSpec{
+			Keys: []v1alpha1.KeyMapping{
+				{
+					Name:         "OPENAI_API_KEY",
+					SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "keys"}, Key: "openai"},
+				},
+			},
+		},
+	}
+	errs := a.Validate(ctx, spec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestPicoClawValidate_EmptyCredentialSpec(t *testing.T) {
+	t.Parallel()
+	a := &PicoClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{
+		Runtime:     v1alpha1.RuntimePicoClaw,
+		Credentials: &v1alpha1.CredentialSpec{},
+	}
+	errs := a.Validate(ctx, spec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for empty credential spec")
+	}
+}
+
+func TestPicoClawValidateUpdate_StorageClassImmutable(t *testing.T) {
+	t.Parallel()
+	a := &PicoClawAdapter{}
+	ctx := context.Background()
+
+	oldSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimePicoClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{
+				Enabled:      true,
+				Size:         "2Gi",
+				MountPath:    "/data/session",
+				StorageClass: "gp3",
+			},
+		},
+	}
+	newSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimePicoClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{
+				Enabled:      true,
+				Size:         "2Gi",
+				MountPath:    "/data/session",
+				StorageClass: "io2",
+			},
+		},
+	}
+
+	errs := a.ValidateUpdate(ctx, oldSpec, newSpec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for storage class change")
+	}
+	found := false
+	for _, e := range errs {
+		if e.Field == "spec.persistence.session.storageClass" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected storageClass field error, got %v", errs)
+	}
+}
+
+func TestPicoClawValidateUpdate_SizeCannotShrink(t *testing.T) {
+	t.Parallel()
+	a := &PicoClawAdapter{}
+	ctx := context.Background()
+
+	oldSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimePicoClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{Enabled: true, Size: "10Gi", MountPath: "/data/session"},
+		},
+	}
+	newSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimePicoClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{Enabled: true, Size: "5Gi", MountPath: "/data/session"},
+		},
+	}
+
+	errs := a.ValidateUpdate(ctx, oldSpec, newSpec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for size shrink")
+	}
+}
+
+func TestPicoClawValidateUpdate_SizeCanGrow(t *testing.T) {
+	t.Parallel()
+	a := &PicoClawAdapter{}
+	ctx := context.Background()
+
+	oldSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimePicoClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{Enabled: true, Size: "5Gi", MountPath: "/data/session"},
+		},
+	}
+	newSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimePicoClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{Enabled: true, Size: "10Gi", MountPath: "/data/session"},
+		},
+	}
+
+	errs := a.ValidateUpdate(ctx, oldSpec, newSpec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for size growth, got %v", errs)
+	}
+}
+
+func TestPicoClawValidateUpdate_NilPersistence(t *testing.T) {
+	t.Parallel()
+	a := &PicoClawAdapter{}
+	ctx := context.Background()
+
+	errs := a.ValidateUpdate(ctx, &v1alpha1.ClawSpec{}, &v1alpha1.ClawSpec{})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}

--- a/internal/runtime/picoclaw_test.go
+++ b/internal/runtime/picoclaw_test.go
@@ -4,98 +4,19 @@ import (
 	"context"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/Prismer-AI/k8s4claw/api/v1alpha1"
 )
 
-func TestPicoClawValidate_RequiresCredentials(t *testing.T) {
+func TestPicoClawValidate_CredentialsOptional(t *testing.T) {
 	t.Parallel()
 	a := &PicoClawAdapter{}
 	ctx := context.Background()
 
+	// PicoClaw supports non-LLM workloads; no credentials required.
 	spec := &v1alpha1.ClawSpec{Runtime: v1alpha1.RuntimePicoClaw}
 	errs := a.Validate(ctx, spec)
-	if len(errs) == 0 {
-		t.Fatal("expected error when credentials are missing")
-	}
-	if errs[0].Field != "spec.credentials" {
-		t.Errorf("field = %q; want spec.credentials", errs[0].Field)
-	}
-}
-
-func TestPicoClawValidate_AcceptsSecretRef(t *testing.T) {
-	t.Parallel()
-	a := &PicoClawAdapter{}
-	ctx := context.Background()
-
-	spec := &v1alpha1.ClawSpec{
-		Runtime: v1alpha1.RuntimePicoClaw,
-		Credentials: &v1alpha1.CredentialSpec{
-			SecretRef: &corev1.LocalObjectReference{Name: "my-secret"},
-		},
-	}
-	errs := a.Validate(ctx, spec)
 	if len(errs) != 0 {
-		t.Fatalf("expected no errors, got %v", errs)
-	}
-}
-
-func TestPicoClawValidate_AcceptsExternalSecret(t *testing.T) {
-	t.Parallel()
-	a := &PicoClawAdapter{}
-	ctx := context.Background()
-
-	spec := &v1alpha1.ClawSpec{
-		Runtime: v1alpha1.RuntimePicoClaw,
-		Credentials: &v1alpha1.CredentialSpec{
-			ExternalSecret: &v1alpha1.ExternalSecretRef{
-				Provider: "vault",
-				Store:    "main",
-				Path:     "secret/picoclaw",
-			},
-		},
-	}
-	errs := a.Validate(ctx, spec)
-	if len(errs) != 0 {
-		t.Fatalf("expected no errors, got %v", errs)
-	}
-}
-
-func TestPicoClawValidate_AcceptsKeyMappingsOnly(t *testing.T) {
-	t.Parallel()
-	a := &PicoClawAdapter{}
-	ctx := context.Background()
-
-	spec := &v1alpha1.ClawSpec{
-		Runtime: v1alpha1.RuntimePicoClaw,
-		Credentials: &v1alpha1.CredentialSpec{
-			Keys: []v1alpha1.KeyMapping{
-				{
-					Name:         "OPENAI_API_KEY",
-					SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "keys"}, Key: "openai"},
-				},
-			},
-		},
-	}
-	errs := a.Validate(ctx, spec)
-	if len(errs) != 0 {
-		t.Fatalf("expected no errors, got %v", errs)
-	}
-}
-
-func TestPicoClawValidate_EmptyCredentialSpec(t *testing.T) {
-	t.Parallel()
-	a := &PicoClawAdapter{}
-	ctx := context.Background()
-
-	spec := &v1alpha1.ClawSpec{
-		Runtime:     v1alpha1.RuntimePicoClaw,
-		Credentials: &v1alpha1.CredentialSpec{},
-	}
-	errs := a.Validate(ctx, spec)
-	if len(errs) == 0 {
-		t.Fatal("expected error for empty credential spec")
+		t.Fatalf("expected no errors for credential-less spec, got %v", errs)
 	}
 }
 

--- a/internal/runtime/zeroclaw.go
+++ b/internal/runtime/zeroclaw.go
@@ -72,10 +72,19 @@ func (a *ZeroClawAdapter) GracefulShutdownSeconds() int32 {
 	return 5
 }
 
-func (a *ZeroClawAdapter) Validate(_ context.Context, _ *v1alpha1.ClawSpec) field.ErrorList {
-	return nil
+func (a *ZeroClawAdapter) Validate(_ context.Context, spec *v1alpha1.ClawSpec) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if !hasCredentials(spec) {
+		allErrs = append(allErrs, field.Required(
+			field.NewPath("spec", "credentials"),
+			"ZeroClaw requires credentials (secretRef, externalSecret, or keys)",
+		))
+	}
+
+	return allErrs
 }
 
-func (a *ZeroClawAdapter) ValidateUpdate(_ context.Context, _, _ *v1alpha1.ClawSpec) field.ErrorList {
-	return nil
+func (a *ZeroClawAdapter) ValidateUpdate(_ context.Context, oldSpec, newSpec *v1alpha1.ClawSpec) field.ErrorList {
+	return validatePersistenceUpdate(oldSpec, newSpec)
 }

--- a/internal/runtime/zeroclaw.go
+++ b/internal/runtime/zeroclaw.go
@@ -72,17 +72,9 @@ func (a *ZeroClawAdapter) GracefulShutdownSeconds() int32 {
 	return 5
 }
 
-func (a *ZeroClawAdapter) Validate(_ context.Context, spec *v1alpha1.ClawSpec) field.ErrorList {
-	var allErrs field.ErrorList
-
-	if !hasCredentials(spec) {
-		allErrs = append(allErrs, field.Required(
-			field.NewPath("spec", "credentials"),
-			"ZeroClaw requires credentials (secretRef, externalSecret, or keys)",
-		))
-	}
-
-	return allErrs
+func (a *ZeroClawAdapter) Validate(_ context.Context, _ *v1alpha1.ClawSpec) field.ErrorList {
+	// ZeroClaw supports non-LLM workloads; credentials are optional.
+	return nil
 }
 
 func (a *ZeroClawAdapter) ValidateUpdate(_ context.Context, oldSpec, newSpec *v1alpha1.ClawSpec) field.ErrorList {

--- a/internal/runtime/zeroclaw_test.go
+++ b/internal/runtime/zeroclaw_test.go
@@ -4,98 +4,19 @@ import (
 	"context"
 	"testing"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/Prismer-AI/k8s4claw/api/v1alpha1"
 )
 
-func TestZeroClawValidate_RequiresCredentials(t *testing.T) {
+func TestZeroClawValidate_CredentialsOptional(t *testing.T) {
 	t.Parallel()
 	a := &ZeroClawAdapter{}
 	ctx := context.Background()
 
+	// ZeroClaw supports non-LLM workloads; no credentials required.
 	spec := &v1alpha1.ClawSpec{Runtime: v1alpha1.RuntimeZeroClaw}
 	errs := a.Validate(ctx, spec)
-	if len(errs) == 0 {
-		t.Fatal("expected error when credentials are missing")
-	}
-	if errs[0].Field != "spec.credentials" {
-		t.Errorf("field = %q; want spec.credentials", errs[0].Field)
-	}
-}
-
-func TestZeroClawValidate_AcceptsSecretRef(t *testing.T) {
-	t.Parallel()
-	a := &ZeroClawAdapter{}
-	ctx := context.Background()
-
-	spec := &v1alpha1.ClawSpec{
-		Runtime: v1alpha1.RuntimeZeroClaw,
-		Credentials: &v1alpha1.CredentialSpec{
-			SecretRef: &corev1.LocalObjectReference{Name: "my-secret"},
-		},
-	}
-	errs := a.Validate(ctx, spec)
 	if len(errs) != 0 {
-		t.Fatalf("expected no errors, got %v", errs)
-	}
-}
-
-func TestZeroClawValidate_AcceptsExternalSecret(t *testing.T) {
-	t.Parallel()
-	a := &ZeroClawAdapter{}
-	ctx := context.Background()
-
-	spec := &v1alpha1.ClawSpec{
-		Runtime: v1alpha1.RuntimeZeroClaw,
-		Credentials: &v1alpha1.CredentialSpec{
-			ExternalSecret: &v1alpha1.ExternalSecretRef{
-				Provider: "vault",
-				Store:    "main",
-				Path:     "secret/zeroclaw",
-			},
-		},
-	}
-	errs := a.Validate(ctx, spec)
-	if len(errs) != 0 {
-		t.Fatalf("expected no errors, got %v", errs)
-	}
-}
-
-func TestZeroClawValidate_AcceptsKeyMappingsOnly(t *testing.T) {
-	t.Parallel()
-	a := &ZeroClawAdapter{}
-	ctx := context.Background()
-
-	spec := &v1alpha1.ClawSpec{
-		Runtime: v1alpha1.RuntimeZeroClaw,
-		Credentials: &v1alpha1.CredentialSpec{
-			Keys: []v1alpha1.KeyMapping{
-				{
-					Name:         "OPENAI_API_KEY",
-					SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "keys"}, Key: "openai"},
-				},
-			},
-		},
-	}
-	errs := a.Validate(ctx, spec)
-	if len(errs) != 0 {
-		t.Fatalf("expected no errors, got %v", errs)
-	}
-}
-
-func TestZeroClawValidate_EmptyCredentialSpec(t *testing.T) {
-	t.Parallel()
-	a := &ZeroClawAdapter{}
-	ctx := context.Background()
-
-	spec := &v1alpha1.ClawSpec{
-		Runtime:     v1alpha1.RuntimeZeroClaw,
-		Credentials: &v1alpha1.CredentialSpec{},
-	}
-	errs := a.Validate(ctx, spec)
-	if len(errs) == 0 {
-		t.Fatal("expected error for empty credential spec")
+		t.Fatalf("expected no errors for credential-less spec, got %v", errs)
 	}
 }
 

--- a/internal/runtime/zeroclaw_test.go
+++ b/internal/runtime/zeroclaw_test.go
@@ -1,0 +1,202 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Prismer-AI/k8s4claw/api/v1alpha1"
+)
+
+func TestZeroClawValidate_RequiresCredentials(t *testing.T) {
+	t.Parallel()
+	a := &ZeroClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{Runtime: v1alpha1.RuntimeZeroClaw}
+	errs := a.Validate(ctx, spec)
+	if len(errs) == 0 {
+		t.Fatal("expected error when credentials are missing")
+	}
+	if errs[0].Field != "spec.credentials" {
+		t.Errorf("field = %q; want spec.credentials", errs[0].Field)
+	}
+}
+
+func TestZeroClawValidate_AcceptsSecretRef(t *testing.T) {
+	t.Parallel()
+	a := &ZeroClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeZeroClaw,
+		Credentials: &v1alpha1.CredentialSpec{
+			SecretRef: &corev1.LocalObjectReference{Name: "my-secret"},
+		},
+	}
+	errs := a.Validate(ctx, spec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestZeroClawValidate_AcceptsExternalSecret(t *testing.T) {
+	t.Parallel()
+	a := &ZeroClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeZeroClaw,
+		Credentials: &v1alpha1.CredentialSpec{
+			ExternalSecret: &v1alpha1.ExternalSecretRef{
+				Provider: "vault",
+				Store:    "main",
+				Path:     "secret/zeroclaw",
+			},
+		},
+	}
+	errs := a.Validate(ctx, spec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestZeroClawValidate_AcceptsKeyMappingsOnly(t *testing.T) {
+	t.Parallel()
+	a := &ZeroClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeZeroClaw,
+		Credentials: &v1alpha1.CredentialSpec{
+			Keys: []v1alpha1.KeyMapping{
+				{
+					Name:         "OPENAI_API_KEY",
+					SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "keys"}, Key: "openai"},
+				},
+			},
+		},
+	}
+	errs := a.Validate(ctx, spec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestZeroClawValidate_EmptyCredentialSpec(t *testing.T) {
+	t.Parallel()
+	a := &ZeroClawAdapter{}
+	ctx := context.Background()
+
+	spec := &v1alpha1.ClawSpec{
+		Runtime:     v1alpha1.RuntimeZeroClaw,
+		Credentials: &v1alpha1.CredentialSpec{},
+	}
+	errs := a.Validate(ctx, spec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for empty credential spec")
+	}
+}
+
+func TestZeroClawValidateUpdate_StorageClassImmutable(t *testing.T) {
+	t.Parallel()
+	a := &ZeroClawAdapter{}
+	ctx := context.Background()
+
+	oldSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeZeroClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{
+				Enabled:      true,
+				Size:         "2Gi",
+				MountPath:    "/data/session",
+				StorageClass: "gp3",
+			},
+		},
+	}
+	newSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeZeroClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{
+				Enabled:      true,
+				Size:         "2Gi",
+				MountPath:    "/data/session",
+				StorageClass: "io2",
+			},
+		},
+	}
+
+	errs := a.ValidateUpdate(ctx, oldSpec, newSpec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for storage class change")
+	}
+	found := false
+	for _, e := range errs {
+		if e.Field == "spec.persistence.session.storageClass" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected storageClass field error, got %v", errs)
+	}
+}
+
+func TestZeroClawValidateUpdate_SizeCannotShrink(t *testing.T) {
+	t.Parallel()
+	a := &ZeroClawAdapter{}
+	ctx := context.Background()
+
+	oldSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeZeroClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{Enabled: true, Size: "10Gi", MountPath: "/data/session"},
+		},
+	}
+	newSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeZeroClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{Enabled: true, Size: "5Gi", MountPath: "/data/session"},
+		},
+	}
+
+	errs := a.ValidateUpdate(ctx, oldSpec, newSpec)
+	if len(errs) == 0 {
+		t.Fatal("expected error for size shrink")
+	}
+}
+
+func TestZeroClawValidateUpdate_SizeCanGrow(t *testing.T) {
+	t.Parallel()
+	a := &ZeroClawAdapter{}
+	ctx := context.Background()
+
+	oldSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeZeroClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{Enabled: true, Size: "5Gi", MountPath: "/data/session"},
+		},
+	}
+	newSpec := &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeZeroClaw,
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{Enabled: true, Size: "10Gi", MountPath: "/data/session"},
+		},
+	}
+
+	errs := a.ValidateUpdate(ctx, oldSpec, newSpec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for size growth, got %v", errs)
+	}
+}
+
+func TestZeroClawValidateUpdate_NilPersistence(t *testing.T) {
+	t.Parallel()
+	a := &ZeroClawAdapter{}
+	ctx := context.Background()
+
+	errs := a.ValidateUpdate(ctx, &v1alpha1.ClawSpec{}, &v1alpha1.ClawSpec{})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}


### PR DESCRIPTION
## Summary
- ZeroClaw and PicoClaw had no-op `Validate()` and `ValidateUpdate()` stubs
- Now match OpenClaw pattern: require credentials on CREATE, reject storage class changes and PVC size reduction on UPDATE
- Adds test files `zeroclaw_test.go` and `picoclaw_test.go` with full coverage

## Test plan
- [ ] `go vet ./internal/runtime/` passes
- [ ] `go test -race ./internal/runtime/` passes
- [ ] Credential validation: missing, empty, secretRef, externalSecret, keys
- [ ] Persistence update: storage class immutability, size shrink rejection, size growth, nil persistence

Fixes #1