### PR TITLE
docs: add local development setup guide (closes #5)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,3 +136,7 @@ For built-in channels, add to `internal/channel/`. For custom channels, use the 
 
 - Open a [Discussion](https://github.com/Prismer-AI/k8s4claw/discussions)
 - Tag your issue with `question` for general questions
+
+## Development Setup
+
+See the [Local Development Setup Guide](docs/dev-setup.md) for instructions on setting up your environment.

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,29 @@
+# Local Development Setup Guide
+
+This guide explains how to set up your local development environment for `k8s4claw`.
+
+## Prerequisites
+
+Before you begin, ensure you have the following tools installed:
+
+*   **Go**: Version 1.24 or later
+*   **kubectl**: The Kubernetes command-line tool
+*   **kind** or **minikube**: For running a local Kubernetes cluster
+*   **make**: For running Makefile targets
+
+## Setup `envtest`
+
+We use `setup-envtest` for running integration tests against a local control plane.
+
+To install and set up `envtest`:
+
+```bash
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+setup-envtest use $(go env GOVERSION)
+```
+
+## Build and Test
+
+*   **Run tests**: `make test`
+*   **Build the binary**: `make build`
+*   **Run locally against a cluster**: `make run`


### PR DESCRIPTION
Adds `docs/dev-setup.md` with required tools, `setup-envtest` instructions, and test/build/run commands as specified in issue #5. Also links the guide in `CONTRIBUTING.md`.