### PR TITLE
feat: add HermesClaw runtime adapter for Hermes Agent

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -6,17 +6,18 @@ import (
 )
 
 // RuntimeType defines the type of Claw runtime.
-// +kubebuilder:validation:Enum=openclaw;nanoclaw;zeroclaw;picoclaw;ironclaw;custom
+// +kubebuilder:validation:Enum=openclaw;nanoclaw;zeroclaw;picoclaw;ironclaw;hermesclaw;custom
 type RuntimeType string
 
 // RuntimeType constants.
 const (
-	RuntimeOpenClaw RuntimeType = "openclaw"
-	RuntimeNanoClaw RuntimeType = "nanoclaw"
-	RuntimeZeroClaw RuntimeType = "zeroclaw"
-	RuntimePicoClaw RuntimeType = "picoclaw"
-	RuntimeIronClaw RuntimeType = "ironclaw"
-	RuntimeCustom   RuntimeType = "custom"
+	RuntimeOpenClaw   RuntimeType = "openclaw"
+	RuntimeNanoClaw   RuntimeType = "nanoclaw"
+	RuntimeZeroClaw   RuntimeType = "zeroclaw"
+	RuntimePicoClaw   RuntimeType = "picoclaw"
+	RuntimeIronClaw   RuntimeType = "ironclaw"
+	RuntimeHermesClaw RuntimeType = "hermesclaw"
+	RuntimeCustom     RuntimeType = "custom"
 )
 
 // ReclaimPolicy defines what happens to PVCs when a Claw is deleted.

--- a/charts/k8s4claw/templates/crds/claw.yaml
+++ b/charts/k8s4claw/templates/crds/claw.yaml
@@ -563,6 +563,7 @@ spec:
                 - zeroclaw
                 - picoclaw
                 - ironclaw
+                - hermesclaw
                 - custom
                 type: string
               security:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -80,6 +80,7 @@ func main() {
 	registry.Register(clawv1alpha1.RuntimeZeroClaw, &clawruntime.ZeroClawAdapter{})
 	registry.Register(clawv1alpha1.RuntimePicoClaw, &clawruntime.PicoClawAdapter{})
 	registry.Register(clawv1alpha1.RuntimeIronClaw, &clawruntime.IronClawAdapter{})
+	registry.Register(clawv1alpha1.RuntimeHermesClaw, &clawruntime.HermesClawAdapter{})
 
 	// Register field indexers.
 	if err := controller.SetupChannelNameIndex(mgr); err != nil {

--- a/config/crd/bases/claw.prismer.ai_claws.yaml
+++ b/config/crd/bases/claw.prismer.ai_claws.yaml
@@ -558,6 +558,7 @@ spec:
                 - zeroclaw
                 - picoclaw
                 - ironclaw
+                - hermesclaw
                 - custom
                 type: string
               security:

--- a/config/samples/hermesclaw-basic.yaml
+++ b/config/samples/hermesclaw-basic.yaml
@@ -1,0 +1,22 @@
+apiVersion: claw.prismer.ai/v1alpha1
+kind: Claw
+metadata:
+  name: hermes-assistant
+spec:
+  runtime: hermesclaw
+  config:
+    model:
+      default: "nous-hermes-3"
+  credentials:
+    secretRef:
+      name: hermes-api-keys
+  persistence:
+    reclaimPolicy: Retain
+    session:
+      enabled: true
+      size: 5Gi
+      mountPath: /opt/data
+    workspace:
+      enabled: true
+      size: 20Gi
+      mountPath: /opt/data/skills

--- a/internal/controller/claw_configmap.go
+++ b/internal/controller/claw_configmap.go
@@ -53,7 +53,7 @@ func (r *ClawReconciler) ensureConfigMap(ctx context.Context, claw *clawv1alpha1
 
 // buildConfigMap constructs the desired ConfigMap for the given Claw and adapter.
 func (r *ClawReconciler) buildConfigMap(claw *clawv1alpha1.Claw, adapter clawruntime.RuntimeAdapter) (*corev1.ConfigMap, error) {
-	defaultJSON, err := clawruntime.DefaultConfigJSON(adapter)
+	defaultJSON, err := defaultConfigJSON(claw, adapter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get default config JSON: %w", err)
 	}
@@ -80,6 +80,13 @@ func (r *ClawReconciler) buildConfigMap(claw *clawv1alpha1.Claw, adapter clawrun
 			"config.json": merged,
 		},
 	}, nil
+}
+
+func defaultConfigJSON(claw *clawv1alpha1.Claw, adapter clawruntime.RuntimeAdapter) (string, error) {
+	if claw.Spec.Runtime == clawv1alpha1.RuntimeHermesClaw {
+		return "{}", nil
+	}
+	return clawruntime.DefaultConfigJSON(adapter)
 }
 
 // mergeConfig deep-merges user config over defaults. If userJSON is nil or

--- a/internal/controller/claw_controller_coverage_test.go
+++ b/internal/controller/claw_controller_coverage_test.go
@@ -573,7 +573,7 @@ func TestClawReconciler_AllRuntimes(t *testing.T) {
 		{clawv1alpha1.RuntimeNanoClaw, 19000, "ghcr.io/prismer-ai/k8s4claw-nanoclaw:latest", 30, false, false},
 		{clawv1alpha1.RuntimeZeroClaw, 3000, "ghcr.io/prismer-ai/k8s4claw-zeroclaw:latest", 20, false, false},
 		{clawv1alpha1.RuntimePicoClaw, 8080, "ghcr.io/prismer-ai/k8s4claw-picoclaw:latest", 17, false, false},
-		{clawv1alpha1.RuntimeHermesClaw, 8642, "docker.io/nousresearch/hermes-agent:latest", 75, true, true},
+		{clawv1alpha1.RuntimeHermesClaw, 8642, "ghcr.io/nousresearch/hermes-agent:latest", 75, true, true},
 	}
 
 	for _, rt := range runtimes {

--- a/internal/controller/claw_controller_coverage_test.go
+++ b/internal/controller/claw_controller_coverage_test.go
@@ -567,10 +567,13 @@ func TestClawReconciler_AllRuntimes(t *testing.T) {
 		gatewayPort int32
 		image       string
 		gracePeriod int64
+		needsCreds  bool
+		emptyConfig bool
 	}{
-		{clawv1alpha1.RuntimeNanoClaw, 19000, "ghcr.io/prismer-ai/k8s4claw-nanoclaw:latest", 30},
-		{clawv1alpha1.RuntimeZeroClaw, 3000, "ghcr.io/prismer-ai/k8s4claw-zeroclaw:latest", 20},
-		{clawv1alpha1.RuntimePicoClaw, 8080, "ghcr.io/prismer-ai/k8s4claw-picoclaw:latest", 17},
+		{clawv1alpha1.RuntimeNanoClaw, 19000, "ghcr.io/prismer-ai/k8s4claw-nanoclaw:latest", 30, false, false},
+		{clawv1alpha1.RuntimeZeroClaw, 3000, "ghcr.io/prismer-ai/k8s4claw-zeroclaw:latest", 20, false, false},
+		{clawv1alpha1.RuntimePicoClaw, 8080, "ghcr.io/prismer-ai/k8s4claw-picoclaw:latest", 17, false, false},
+		{clawv1alpha1.RuntimeHermesClaw, 8642, "docker.io/nousresearch/hermes-agent:latest", 75, true, true},
 	}
 
 	for _, rt := range runtimes {
@@ -587,6 +590,15 @@ func TestClawReconciler_AllRuntimes(t *testing.T) {
 				Spec: clawv1alpha1.ClawSpec{
 					Runtime: rt.name,
 				},
+			}
+			if rt.needsCreds {
+				ensureTestSecret(t, ns)
+				claw.Spec.Credentials = testCredentials()
+			}
+			if rt.name == clawv1alpha1.RuntimeHermesClaw {
+				claw.Annotations = map[string]string{
+					annotationTargetImage: rt.image,
+				}
 			}
 			if err := k8sClient.Create(ctx, claw); err != nil {
 				t.Fatalf("failed to create Claw: %v", err)
@@ -651,7 +663,11 @@ func TestClawReconciler_AllRuntimes(t *testing.T) {
 			if err := json.Unmarshal([]byte(cm.Data["config.json"]), &parsed); err != nil {
 				t.Fatalf("config.json is not valid JSON: %v", err)
 			}
-			if gp, ok := parsed["gatewayPort"]; !ok || int(gp.(float64)) != int(rt.gatewayPort) {
+			if rt.emptyConfig {
+				if len(parsed) != 0 {
+					t.Errorf("expected empty Hermes config defaults, got %v", parsed)
+				}
+			} else if gp, ok := parsed["gatewayPort"]; !ok || int(gp.(float64)) != int(rt.gatewayPort) {
 				t.Errorf("expected gatewayPort=%d, got %v", rt.gatewayPort, parsed["gatewayPort"])
 			}
 		})
@@ -1425,6 +1441,7 @@ func newFakeReconciler(c client.Client) *ClawReconciler {
 	registry.Register(clawv1alpha1.RuntimeNanoClaw, &clawruntime.NanoClawAdapter{})
 	registry.Register(clawv1alpha1.RuntimeZeroClaw, &clawruntime.ZeroClawAdapter{})
 	registry.Register(clawv1alpha1.RuntimePicoClaw, &clawruntime.PicoClawAdapter{})
+	registry.Register(clawv1alpha1.RuntimeHermesClaw, &clawruntime.HermesClawAdapter{})
 	return &ClawReconciler{
 		Client:                c,
 		Scheme:                scheme.Scheme,
@@ -2511,6 +2528,7 @@ func incompleteSchemeReconciler(c client.Client) *ClawReconciler {
 
 	registry := clawruntime.NewRegistry()
 	registry.Register(clawv1alpha1.RuntimeOpenClaw, &clawruntime.OpenClawAdapter{})
+	registry.Register(clawv1alpha1.RuntimeHermesClaw, &clawruntime.HermesClawAdapter{})
 	return &ClawReconciler{
 		Client:                c,
 		Scheme:                incompleteScheme,
@@ -2600,6 +2618,53 @@ func TestBuildConfigMap_MergeConfigError(t *testing.T) {
 	}
 	if !containsSubstring(err.Error(), "merge config") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildConfigMap_HermesClawUsesUserConfigOnly(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	r := newFakeReconciler(fakeClient)
+	adapter, _ := r.Registry.Get(clawv1alpha1.RuntimeHermesClaw)
+
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-hermes-config", Namespace: "default"},
+		Spec: clawv1alpha1.ClawSpec{
+			Runtime: clawv1alpha1.RuntimeHermesClaw,
+			Config: &apiextensionsv1.JSON{
+				Raw: []byte(`{"model":{"default":"nous-hermes-3"},"learningEnabled":true}`),
+			},
+		},
+	}
+
+	cm, err := r.buildConfigMap(claw, adapter)
+	if err != nil {
+		t.Fatalf("buildConfigMap: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(cm.Data["config.json"]), &parsed); err != nil {
+		t.Fatalf("config.json is not valid JSON: %v", err)
+	}
+
+	if _, ok := parsed["gatewayPort"]; ok {
+		t.Fatalf("expected Hermes config to omit gatewayPort defaults, got %v", parsed["gatewayPort"])
+	}
+	if _, ok := parsed["workspacePath"]; ok {
+		t.Fatalf("expected Hermes config to omit workspacePath defaults, got %v", parsed["workspacePath"])
+	}
+	if _, ok := parsed["environment"]; ok {
+		t.Fatalf("expected Hermes config to omit environment defaults, got %v", parsed["environment"])
+	}
+	if parsed["learningEnabled"] != true {
+		t.Fatalf("expected learningEnabled=true, got %v", parsed["learningEnabled"])
+	}
+
+	model, ok := parsed["model"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected model object, got %T", parsed["model"])
+	}
+	if model["default"] != "nous-hermes-3" {
+		t.Fatalf("expected model.default=nous-hermes-3, got %v", model["default"])
 	}
 }
 

--- a/internal/controller/e2e_lifecycle_test.go
+++ b/internal/controller/e2e_lifecycle_test.go
@@ -226,7 +226,7 @@ func TestE2E_MultiRuntime(t *testing.T) {
 		{clawv1alpha1.RuntimeZeroClaw, "ghcr.io/prismer-ai/k8s4claw-zeroclaw:latest", 3000, false},
 		{clawv1alpha1.RuntimePicoClaw, "ghcr.io/prismer-ai/k8s4claw-picoclaw:latest", 8080, false},
 		{clawv1alpha1.RuntimeIronClaw, "ghcr.io/prismer-ai/k8s4claw-ironclaw:latest", 3001, true},
-		{clawv1alpha1.RuntimeHermesClaw, "docker.io/nousresearch/hermes-agent:latest", 8642, true},
+		{clawv1alpha1.RuntimeHermesClaw, "ghcr.io/nousresearch/hermes-agent:latest", 8642, true},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/e2e_lifecycle_test.go
+++ b/internal/controller/e2e_lifecycle_test.go
@@ -226,6 +226,7 @@ func TestE2E_MultiRuntime(t *testing.T) {
 		{clawv1alpha1.RuntimeZeroClaw, "ghcr.io/prismer-ai/k8s4claw-zeroclaw:latest", 3000, false},
 		{clawv1alpha1.RuntimePicoClaw, "ghcr.io/prismer-ai/k8s4claw-picoclaw:latest", 8080, false},
 		{clawv1alpha1.RuntimeIronClaw, "ghcr.io/prismer-ai/k8s4claw-ironclaw:latest", 3001, true},
+		{clawv1alpha1.RuntimeHermesClaw, "docker.io/nousresearch/hermes-agent:latest", 8642, true},
 	}
 
 	for _, tt := range tests {
@@ -242,6 +243,11 @@ func TestE2E_MultiRuntime(t *testing.T) {
 			claw := &clawv1alpha1.Claw{
 				ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: ns},
 				Spec:       spec,
+			}
+			if tt.runtime == clawv1alpha1.RuntimeHermesClaw {
+				claw.Annotations = map[string]string{
+					annotationTargetImage: tt.wantImage,
+				}
 			}
 			if err := k8sClient.Create(ctx, claw); err != nil {
 				t.Fatalf("failed to create Claw: %v", err)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -68,6 +68,7 @@ func TestMain(m *testing.M) {
 	registry.Register(clawv1alpha1.RuntimeZeroClaw, &clawruntime.ZeroClawAdapter{})
 	registry.Register(clawv1alpha1.RuntimePicoClaw, &clawruntime.PicoClawAdapter{})
 	registry.Register(clawv1alpha1.RuntimeIronClaw, &clawruntime.IronClawAdapter{})
+	registry.Register(clawv1alpha1.RuntimeHermesClaw, &clawruntime.HermesClawAdapter{})
 
 	// Configure webhook server using envtest-assigned host/port/certs.
 	webhookInstallOptions := &testEnv.WebhookInstallOptions

--- a/internal/registry/resolver.go
+++ b/internal/registry/resolver.go
@@ -271,6 +271,8 @@ func ImageForRuntime(runtime string) string {
 		return "ghcr.io/prismer-ai/k8s4claw-picoclaw"
 	case "ironclaw":
 		return "ghcr.io/prismer-ai/k8s4claw-ironclaw"
+	case "hermesclaw":
+		return "ghcr.io/nousresearch/hermes-agent"
 	default:
 		return ""
 	}

--- a/internal/registry/resolver_test.go
+++ b/internal/registry/resolver_test.go
@@ -170,6 +170,7 @@ func TestImageForRuntime(t *testing.T) {
 		{"zeroclaw", "ghcr.io/prismer-ai/k8s4claw-zeroclaw"},
 		{"picoclaw", "ghcr.io/prismer-ai/k8s4claw-picoclaw"},
 		{"ironclaw", "ghcr.io/prismer-ai/k8s4claw-ironclaw"},
+		{"hermesclaw", "ghcr.io/nousresearch/hermes-agent"},
 		{"unknown", ""},
 		{"", ""},
 	}

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -135,6 +135,26 @@ func allAdapterTests() []adapterTestCase {
 				initialDelay: 10, period: 10,
 			},
 		},
+		{
+			name:    "HermesClaw",
+			adapter: &HermesClawAdapter{},
+			runtime: v1alpha1.RuntimeHermesClaw,
+
+			wantPort:      8642,
+			wantWorkspace: "/opt/data/skills",
+			wantEnvKey:    "HERMES_HOME",
+			wantEnvValue:  "/opt/data",
+			wantShutdown:  60,
+
+			wantHealth: probeExpectation{
+				probeType: "http", path: "/health", port: 8642,
+				initialDelay: 20, period: 15,
+			},
+			wantReady: probeExpectation{
+				probeType: "http", path: "/health", port: 8642,
+				initialDelay: 10, period: 10,
+			},
+		},
 	}
 }
 

--- a/internal/runtime/hermesclaw.go
+++ b/internal/runtime/hermesclaw.go
@@ -1,0 +1,161 @@
+package runtime
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+
+	"github.com/Prismer-AI/k8s4claw/api/v1alpha1"
+)
+
+const (
+	hermesGatewayPort      = 8642
+	hermesHomePath         = "/opt/data"
+	hermesSkillsPath       = "/opt/data/skills"
+	hermesDefaultModelName = "hermes-agent"
+)
+
+// HermesClawAdapter implements RuntimeAdapter for the Hermes Agent runtime.
+type HermesClawAdapter struct{}
+
+var _ RuntimeAdapter = (*HermesClawAdapter)(nil)
+
+func (a *HermesClawAdapter) PodTemplate(claw *v1alpha1.Claw) *corev1.PodTemplateSpec {
+	return BuildPodTemplate(claw, a.runtimeSpec(claw))
+}
+
+func (a *HermesClawAdapter) runtimeSpec(_ *v1alpha1.Claw) *RuntimeSpec {
+	return &RuntimeSpec{
+		Image:     "ghcr.io/nousresearch/hermes-agent:latest",
+		Args:      []string{"gateway", "run"},
+		Ports:     []corev1.ContainerPort{{Name: "gateway", ContainerPort: hermesGatewayPort, Protocol: corev1.ProtocolTCP}},
+		Resources: resources("500m", "1Gi", "2000m", "4Gi"),
+		ExtraVolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "config-vol",
+				MountPath: hermesHomePath + "/config.yaml",
+				SubPath:   "config.json",
+				ReadOnly:  true,
+			},
+		},
+		Env: []corev1.EnvVar{
+			{Name: "HERMES_HOME", Value: hermesHomePath},
+			{Name: "HOME", Value: hermesHomePath + "/home"},
+			{Name: "API_SERVER_ENABLED", Value: "true"},
+			{Name: "API_SERVER_HOST", Value: "0.0.0.0"},
+			{Name: "API_SERVER_PORT", Value: "8642"},
+			{Name: "API_SERVER_MODEL_NAME", Value: hermesDefaultModelName},
+		},
+		LivenessProbe:   a.HealthProbe(nil),
+		ReadinessProbe:  a.ReadinessProbe(nil),
+		ConfigMode:      ConfigModeDeepMerge,
+		WorkspacePath:   hermesSkillsPath,
+		SecurityContext: hermesRuntimeSecurityContext(),
+	}
+}
+
+func (a *HermesClawAdapter) HealthProbe(_ *v1alpha1.Claw) *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/health",
+				Port: portIntStr(hermesGatewayPort),
+			},
+		},
+		InitialDelaySeconds: 20,
+		PeriodSeconds:       15,
+		TimeoutSeconds:      5,
+	}
+}
+
+func (a *HermesClawAdapter) ReadinessProbe(_ *v1alpha1.Claw) *corev1.Probe {
+	return &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/health",
+				Port: portIntStr(hermesGatewayPort),
+			},
+		},
+		InitialDelaySeconds: 10,
+		PeriodSeconds:       10,
+		TimeoutSeconds:      5,
+	}
+}
+
+func (a *HermesClawAdapter) DefaultConfig() *RuntimeConfig {
+	return &RuntimeConfig{
+		GatewayPort:   hermesGatewayPort,
+		WorkspacePath: hermesSkillsPath,
+		Environment: map[string]string{
+			"HERMES_HOME":           hermesHomePath,
+			"HOME":                  hermesHomePath + "/home",
+			"API_SERVER_ENABLED":    "true",
+			"API_SERVER_HOST":       "0.0.0.0",
+			"API_SERVER_PORT":       "8642",
+			"API_SERVER_MODEL_NAME": hermesDefaultModelName,
+		},
+	}
+}
+
+func (a *HermesClawAdapter) GracefulShutdownSeconds() int32 {
+	return 60
+}
+
+func (a *HermesClawAdapter) Validate(_ context.Context, spec *v1alpha1.ClawSpec) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if !hasCredentials(spec) {
+		allErrs = append(allErrs, field.Required(
+			field.NewPath("spec", "credentials"),
+			"HermesClaw requires credentials (secretRef, externalSecret, or keys)",
+		))
+	}
+
+	if len(spec.Channels) > 0 {
+		allErrs = append(allErrs, field.Forbidden(
+			field.NewPath("spec", "channels"),
+			"HermesClaw does not support k8s4claw channel sidecars yet; use Hermes native gateway integrations for now",
+		))
+	}
+
+	if spec.Persistence != nil {
+		if p := spec.Persistence.Session; p != nil && p.Enabled && p.MountPath != hermesHomePath {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "persistence", "session", "mountPath"),
+				p.MountPath,
+				"HermesClaw session storage must mount at /opt/data",
+			))
+		}
+		if p := spec.Persistence.Workspace; p != nil && p.Enabled && p.MountPath != hermesSkillsPath {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "persistence", "workspace", "mountPath"),
+				p.MountPath,
+				"HermesClaw workspace storage must mount at /opt/data/skills",
+			))
+		}
+	}
+
+	return allErrs
+}
+
+func (a *HermesClawAdapter) ValidateUpdate(_ context.Context, oldSpec, newSpec *v1alpha1.ClawSpec) field.ErrorList {
+	return validatePersistenceUpdate(oldSpec, newSpec)
+}
+
+func hermesRuntimeSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		RunAsUser:                ptr.To(int64(10000)),
+		RunAsGroup:               ptr.To(int64(10000)),
+		RunAsNonRoot:             ptr.To(true),
+		ReadOnlyRootFilesystem:   ptr.To(false),
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}

--- a/internal/runtime/hermesclaw_test.go
+++ b/internal/runtime/hermesclaw_test.go
@@ -1,0 +1,174 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/Prismer-AI/k8s4claw/api/v1alpha1"
+)
+
+func TestHermesClawValidate_RequiresCredentials(t *testing.T) {
+	t.Parallel()
+
+	a := &HermesClawAdapter{}
+	errs := a.Validate(context.Background(), &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeHermesClaw,
+	})
+	if len(errs) == 0 {
+		t.Fatal("expected error when credentials are missing")
+	}
+	if errs[0].Field != "spec.credentials" {
+		t.Fatalf("field = %q, want spec.credentials", errs[0].Field)
+	}
+}
+
+func TestHermesClawValidate_RejectsChannels(t *testing.T) {
+	t.Parallel()
+
+	a := &HermesClawAdapter{}
+	errs := a.Validate(context.Background(), &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeHermesClaw,
+		Credentials: &v1alpha1.CredentialSpec{
+			SecretRef: &corev1.LocalObjectReference{Name: "hermes-creds"},
+		},
+		Channels: []v1alpha1.ChannelRef{{Name: "slack-team"}},
+	})
+	if len(errs) == 0 {
+		t.Fatal("expected error when channels are configured")
+	}
+	found := false
+	for _, err := range errs {
+		if err.Field == "spec.channels" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected spec.channels validation error, got %v", errs)
+	}
+}
+
+func TestHermesClawValidate_RequiresHermesMountPaths(t *testing.T) {
+	t.Parallel()
+
+	a := &HermesClawAdapter{}
+	errs := a.Validate(context.Background(), &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeHermesClaw,
+		Credentials: &v1alpha1.CredentialSpec{
+			SecretRef: &corev1.LocalObjectReference{Name: "hermes-creds"},
+		},
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{
+				Enabled:   true,
+				Size:      "5Gi",
+				MountPath: "/data/memory",
+			},
+			Workspace: &v1alpha1.VolumeSpec{
+				Enabled:   true,
+				Size:      "10Gi",
+				MountPath: "/data/skills",
+			},
+		},
+	})
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 mountPath errors, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestHermesClawValidate_AcceptsSupportedPaths(t *testing.T) {
+	t.Parallel()
+
+	a := &HermesClawAdapter{}
+	errs := a.Validate(context.Background(), &v1alpha1.ClawSpec{
+		Runtime: v1alpha1.RuntimeHermesClaw,
+		Credentials: &v1alpha1.CredentialSpec{
+			SecretRef: &corev1.LocalObjectReference{Name: "hermes-creds"},
+		},
+		Persistence: &v1alpha1.PersistenceSpec{
+			Session: &v1alpha1.VolumeSpec{
+				Enabled:   true,
+				Size:      "5Gi",
+				MountPath: "/opt/data",
+			},
+			Workspace: &v1alpha1.VolumeSpec{
+				Enabled:   true,
+				Size:      "20Gi",
+				MountPath: "/opt/data/skills",
+			},
+		},
+	})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestHermesClawPodTemplate_UsesWritableRootAndGatewayArgs(t *testing.T) {
+	t.Parallel()
+
+	a := &HermesClawAdapter{}
+	tmpl := a.PodTemplate(&v1alpha1.Claw{
+		Spec: v1alpha1.ClawSpec{
+			Runtime: v1alpha1.RuntimeHermesClaw,
+		},
+	})
+
+	if len(tmpl.Spec.Containers) != 1 {
+		t.Fatalf("expected 1 runtime container, got %d", len(tmpl.Spec.Containers))
+	}
+	runtime := tmpl.Spec.Containers[0]
+	if len(runtime.Args) != 2 || runtime.Args[0] != "gateway" || runtime.Args[1] != "run" {
+		t.Fatalf("runtime args = %v, want [gateway run]", runtime.Args)
+	}
+	if runtime.SecurityContext == nil || runtime.SecurityContext.ReadOnlyRootFilesystem == nil || *runtime.SecurityContext.ReadOnlyRootFilesystem {
+		t.Fatal("expected writable root filesystem for Hermes runtime")
+	}
+	if runtime.SecurityContext.RunAsUser == nil || *runtime.SecurityContext.RunAsUser != 10000 {
+		t.Fatalf("runtime RunAsUser = %v, want 10000", runtime.SecurityContext.RunAsUser)
+	}
+
+	foundConfigMount := false
+	for _, mount := range runtime.VolumeMounts {
+		if mount.Name == "config-vol" && mount.MountPath == "/opt/data/config.yaml" && mount.SubPath == "config.json" {
+			foundConfigMount = true
+			break
+		}
+	}
+	if !foundConfigMount {
+		t.Fatal("expected Hermes config-vol subPath mount at /opt/data/config.yaml")
+	}
+}
+
+func TestHermesClawValidateUpdate_UsesStandardPersistenceRules(t *testing.T) {
+	t.Parallel()
+
+	a := &HermesClawAdapter{}
+	errs := a.ValidateUpdate(context.Background(),
+		&v1alpha1.ClawSpec{
+			Runtime: v1alpha1.RuntimeHermesClaw,
+			Persistence: &v1alpha1.PersistenceSpec{
+				Session: &v1alpha1.VolumeSpec{
+					Enabled:      true,
+					Size:         "10Gi",
+					MountPath:    "/opt/data",
+					StorageClass: "gp3",
+				},
+			},
+		},
+		&v1alpha1.ClawSpec{
+			Runtime: v1alpha1.RuntimeHermesClaw,
+			Persistence: &v1alpha1.PersistenceSpec{
+				Session: &v1alpha1.VolumeSpec{
+					Enabled:      true,
+					Size:         "5Gi",
+					MountPath:    "/opt/data",
+					StorageClass: "gp3",
+				},
+			},
+		},
+	)
+	if len(errs) == 0 {
+		t.Fatal("expected error when Hermes session PVC shrinks")
+	}
+}

--- a/internal/runtime/pod_builder.go
+++ b/internal/runtime/pod_builder.go
@@ -38,6 +38,7 @@ type RuntimeSpec struct {
 	ReadinessProbe    *corev1.Probe
 	ConfigMode        ConfigMergeMode
 	WorkspacePath     string
+	SecurityContext   *corev1.SecurityContext
 }
 
 // ---------------------------------------------------------------------------
@@ -278,6 +279,11 @@ func buildRuntimeContainer(claw *v1alpha1.Claw, spec *RuntimeSpec) corev1.Contai
 	// Adapter-specific extra mounts.
 	mounts = append(mounts, spec.ExtraVolumeMounts...)
 
+	securityContext := spec.SecurityContext
+	if securityContext == nil {
+		securityContext = ContainerSecurityContext()
+	}
+
 	return corev1.Container{
 		Name:            "runtime",
 		Image:           spec.Image,
@@ -289,7 +295,7 @@ func buildRuntimeContainer(claw *v1alpha1.Claw, spec *RuntimeSpec) corev1.Contai
 		Resources:       spec.Resources,
 		LivenessProbe:   spec.LivenessProbe,
 		ReadinessProbe:  spec.ReadinessProbe,
-		SecurityContext: ContainerSecurityContext(),
+		SecurityContext: securityContext,
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{
 				Exec: &corev1.ExecAction{
@@ -307,11 +313,15 @@ func buildRuntimeContainer(claw *v1alpha1.Claw, spec *RuntimeSpec) corev1.Contai
 // ContainerSecurityContext returns the hardened security context applied to
 // every container in a Claw pod.
 func ContainerSecurityContext() *corev1.SecurityContext {
+	return containerSecurityContext(true)
+}
+
+func containerSecurityContext(readOnlyRoot bool) *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		RunAsUser:                ptr.To(int64(1000)),
 		RunAsGroup:               ptr.To(int64(1000)),
 		RunAsNonRoot:             ptr.To(true),
-		ReadOnlyRootFilesystem:   ptr.To(true),
+		ReadOnlyRootFilesystem:   ptr.To(readOnlyRoot),
 		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -68,11 +68,12 @@ func TestRegistry_MultipleRuntimes(t *testing.T) {
 	r := NewRegistry()
 
 	adapters := map[v1alpha1.RuntimeType]RuntimeAdapter{
-		v1alpha1.RuntimeOpenClaw: &OpenClawAdapter{},
-		v1alpha1.RuntimeNanoClaw: &NanoClawAdapter{},
-		v1alpha1.RuntimeZeroClaw: &ZeroClawAdapter{},
-		v1alpha1.RuntimePicoClaw: &PicoClawAdapter{},
-		v1alpha1.RuntimeIronClaw: &IronClawAdapter{},
+		v1alpha1.RuntimeOpenClaw:   &OpenClawAdapter{},
+		v1alpha1.RuntimeNanoClaw:   &NanoClawAdapter{},
+		v1alpha1.RuntimeZeroClaw:   &ZeroClawAdapter{},
+		v1alpha1.RuntimePicoClaw:   &PicoClawAdapter{},
+		v1alpha1.RuntimeIronClaw:   &IronClawAdapter{},
+		v1alpha1.RuntimeHermesClaw: &HermesClawAdapter{},
 	}
 
 	for rt, adapter := range adapters {

--- a/internal/webhook/claw_validator.go
+++ b/internal/webhook/claw_validator.go
@@ -138,6 +138,7 @@ func (v *ClawValidator) validateRuntime(ctx context.Context, obj *clawv1alpha1.C
 				string(clawv1alpha1.RuntimeZeroClaw),
 				string(clawv1alpha1.RuntimePicoClaw),
 				string(clawv1alpha1.RuntimeIronClaw),
+				string(clawv1alpha1.RuntimeHermesClaw),
 			}),
 		}
 	}

--- a/internal/webhook/claw_validator_test.go
+++ b/internal/webhook/claw_validator_test.go
@@ -18,6 +18,7 @@ func newRegistry() *clawruntime.Registry {
 	reg.Register(clawv1alpha1.RuntimeZeroClaw, &clawruntime.ZeroClawAdapter{})
 	reg.Register(clawv1alpha1.RuntimePicoClaw, &clawruntime.PicoClawAdapter{})
 	reg.Register(clawv1alpha1.RuntimeIronClaw, &clawruntime.IronClawAdapter{})
+	reg.Register(clawv1alpha1.RuntimeHermesClaw, &clawruntime.HermesClawAdapter{})
 	return reg
 }
 
@@ -153,6 +154,21 @@ func TestValidateCreate_RuntimeAdapterValidation(t *testing.T) {
 	}
 	if len(warnings) > 0 {
 		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestValidateCreate_HermesClawRejectsChannels(t *testing.T) {
+	v := &ClawValidator{Registry: newRegistry()}
+	claw := baseClaw()
+	claw.Spec.Runtime = clawv1alpha1.RuntimeHermesClaw
+	claw.Spec.Channels = []clawv1alpha1.ChannelRef{{Name: "slack-team"}}
+
+	_, err := v.ValidateCreate(context.Background(), claw)
+	if err == nil {
+		t.Fatal("expected error for HermesClaw channels, got nil")
+	}
+	if !containsFieldError(err.Error(), "channels") {
+		t.Fatalf("error should mention channels: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

  Add first-class `hermesclaw` runtime support for Hermes Agent across the API, runtime, controller, webhook, registry, and sample manifests.

  ## Why

  This change allows Hermes Agent to run as a managed Claw runtime instead of being handled as a custom integration.

  Hermes has runtime-specific requirements, including mandatory credentials, a writable root filesystem, fixed persistence mount paths (`/opt/data` and `/opt/data/skills`), and no support
  for k8s4claw channel sidecars yet. Those differences require a dedicated runtime adapter and validation path.

  ## How

  - add `hermesclaw` to the runtime enum, CRD manifests, runtime registry, webhook allowlist, and registry image resolution
  - introduce a `HermesClawAdapter` with Hermes-specific image/args, port `8642`, probes, environment variables, shutdown behavior, security context, and persistence validation
  - extend pod building to support runtime-specific config merge mode, workspace path, and security context so Hermes can use its native filesystem layout
  - treat Hermes config as user-owned by building its ConfigMap from `{}` instead of injecting the generic k8s4claw default runtime config
  - add a basic `hermesclaw` sample and expand unit/integration coverage for adapter behavior, validator rules, ConfigMap generation, resolver mapping, and multi-runtime lifecycle
  reconciliation

  ## Checklist

  - [x] Tests added/updated
  - [ ] `make lint` passes
  - [ ] `make test` passes
  - [x] Generated files up to date (`make generate && make manifests`)
  - [ ] Documentation updated (if applicable)
  - [ ] Commits signed off (`git commit -s`) per [DCO](../DCO)

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [ ] Documentation
  - [ ] CI/CD
  - [ ] Refactor