### PR TITLE
fix(helm): add claw4k8s CRD + RBAC to Helm chart (v0.2.1)

### DIFF
--- a/charts/k8s4claw/Chart.yaml
+++ b/charts/k8s4claw/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k8s4claw
 description: Kubernetes operator for managing Claw AI agent runtimes
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.1
+appVersion: "0.2.1"
 kubeVersion: ">=1.28.0-0"
 home: https://github.com/Prismer-AI/k8s4claw
 maintainers:

--- a/charts/k8s4claw/templates/clusterrole.yaml
+++ b/charts/k8s4claw/templates/clusterrole.yaml
@@ -37,13 +37,18 @@ rules:
 
   # CRDs
   - apiGroups: ["claw.prismer.ai"]
-    resources: [claws, claws/status, clawchannels, clawchannels/status, clawselfconfigs, clawselfconfigs/status]
+    resources: [claws, claws/status, clawchannels, clawchannels/status, clawselfconfigs, clawselfconfigs/status, clawopsescalations, clawopsescalations/status]
     verbs: [get, list, watch, create, update, patch, delete]
 
   # CRD finalizer subresources
   - apiGroups: ["claw.prismer.ai"]
-    resources: [claws/finalizers, clawchannels/finalizers, clawselfconfigs/finalizers]
+    resources: [claws/finalizers, clawchannels/finalizers, clawselfconfigs/finalizers, clawopsescalations/finalizers]
     verbs: [update]
+
+  # Pod logs (ClawOpsController — optional, for richer escalation context)
+  - apiGroups: [""]
+    resources: [pods/log]
+    verbs: [get]
 
   # ExternalSecrets (optional)
   - apiGroups: ["external-secrets.io"]

--- a/charts/k8s4claw/templates/crds/clawopsescalation.yaml
+++ b/charts/k8s4claw/templates/crds/clawopsescalation.yaml
@@ -1,0 +1,215 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/resource-policy": keep
+  name: clawopsescalations.claw.prismer.ai
+  labels:
+    {{- include "k8s4claw.labels" . | nindent 4 }}
+spec:
+  group: claw.prismer.ai
+  names:
+    kind: ClawOpsEscalation
+    listKind: ClawOpsEscalationList
+    plural: clawopsescalations
+    singular: clawopsescalation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.clawRef.name
+      name: Claw
+      type: string
+    - jsonPath: .spec.trigger.type
+      name: Trigger
+      type: string
+    - jsonPath: .spec.severity
+      name: Severity
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClawOpsEscalation is the Schema for the clawopsescalations API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClawOpsEscalationSpec defines the desired state of a ClawOpsEscalation.
+            properties:
+              clawRef:
+                description: ClawRef references the target Claw instance (same namespace).
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              eventSnapshot:
+                description: EventSnapshot is a snapshot of recent Kubernetes events
+                  for the target Claw.
+                items:
+                  description: EventRecord captures a single Kubernetes event from
+                    the escalation context.
+                  properties:
+                    message:
+                      description: Message is the human-readable event message.
+                      type: string
+                    reason:
+                      description: Reason is the short machine-readable reason string.
+                      type: string
+                    timestamp:
+                      description: Timestamp is when the event occurred.
+                      format: date-time
+                      type: string
+                    type:
+                      description: Type is the event type (Normal, Warning).
+                      type: string
+                  required:
+                  - reason
+                  - timestamp
+                  - type
+                  type: object
+                type: array
+              metricSnapshot:
+                description: MetricSnapshot holds a freeform snapshot of relevant
+                  metrics at trigger time.
+                x-kubernetes-preserve-unknown-fields: true
+              severity:
+                description: Severity is the urgency level of this escalation.
+                enum:
+                - Critical
+                - High
+                - Medium
+                - Low
+                type: string
+              trigger:
+                description: Trigger describes the Kubernetes event that initiated
+                  this escalation.
+                properties:
+                  count:
+                    description: Count is the number of times this event has occurred.
+                    format: int32
+                    type: integer
+                  firstSeen:
+                    description: FirstSeen is when the triggering condition was first
+                      observed.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human-readable description of the event.
+                    type: string
+                  type:
+                    description: Type is the trigger event type.
+                    enum:
+                    - OOMKilled
+                    - CrashLoop
+                    - HighCPU
+                    - HighMemory
+                    - PodPending
+                    - ProbeFailure
+                    - ChannelDisconnect
+                    - Evicted
+                    - Unknown
+                    type: string
+                required:
+                - type
+                type: object
+              ttlSecondsAfterFinished:
+                description: TTLSecondsAfterFinished is how long to keep the resource
+                  after reaching a terminal phase.
+                format: int32
+                type: integer
+            required:
+            - clawRef
+            - severity
+            - trigger
+            type: object
+          status:
+            description: ClawOpsEscalationStatus defines the observed state of a ClawOpsEscalation.
+            properties:
+              analysis:
+                description: Analysis is the AI-generated analysis of the incident.
+                type: string
+              approvedAt:
+                description: ApprovedAt is the timestamp when the escalation was approved.
+                format: date-time
+                type: string
+              approvedBy:
+                description: ApprovedBy is the identity that approved the escalation
+                  (user or policy).
+                type: string
+              executedAction:
+                description: ExecutedAction describes the remediation action that
+                  was actually executed.
+                type: string
+              executedAt:
+                description: ExecutedAt is the timestamp when the action was executed.
+                format: date-time
+                type: string
+              matchedRule:
+                description: MatchedRule is the name of the escalation rule that matched
+                  this trigger.
+                type: string
+              phase:
+                description: Phase is the current lifecycle phase.
+                enum:
+                - Pending
+                - AutoExecuted
+                - Analyzing
+                - Proposed
+                - AwaitingApproval
+                - Approved
+                - Executed
+                - Rejected
+                - Failed
+                type: string
+              proposedAction:
+                description: ProposedAction describes the remediation action proposed
+                  by the operator.
+                type: string
+              rejectionReason:
+                description: RejectionReason explains why the escalation was rejected.
+                type: string
+              result:
+                description: Result is the outcome of the executed action.
+                type: string
+              signetReceipt:
+                description: SignetReceipt is the cryptographic receipt for audit
+                  trail.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
## Summary

v0.2.0 shipped claw4k8s but the Helm chart wasn't updated. Helm-installed operators fail at startup with:

\`\`\`
unable to set up channel name field index: no matches for kind "ClawOpsEscalation"
\`\`\`

This hotfix adds the missing resources.

## Changes

- `charts/k8s4claw/templates/crds/clawopsescalation.yaml` — full CRD template with pre-install hook
- `charts/k8s4claw/templates/clusterrole.yaml` — adds `clawopsescalations` (+ `/status`, `/finalizers`) verbs; adds `pods/log` read for escalation context
- `charts/k8s4claw/Chart.yaml` — bump version + appVersion to `0.2.1`

## Verification

- [x] `helm lint` passes (only "icon recommended" info)
- [x] `helm template` renders 14 documents, no errors
- [x] `helm install --dry-run` renders cleanly (with `webhook.certManager.enabled=false`)
- [x] `kubectl apply` on real kind cluster: CRD accepted, ClusterRole has the new resources/verbs

## Test plan

After merge + v0.2.1 tag:
- [ ] `helm install k8s4claw charts/k8s4claw --version 0.2.1 --set webhook.certManager.enabled=false` on a fresh kind cluster
- [ ] Verify operator pod reaches Running (no startup error)
- [ ] Create a Claw CR with `runtime: openclaw` — confirm StatefulSet appears
- [ ] Simulate OOM via `scripts/demo-claw4k8s.sh` — confirm ClawOpsEscalation CR is created

🤖 Generated with [Claude Code](https://claude.ai/code)