### PR TITLE
docs(readme): clarify HermesClaw is internal wrapper, not upstream name

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,16 +110,18 @@ Channel Sidecar ──UDS──► IPC Bus ──Bridge──► Runtime Contain
 
 ## Supported Runtimes
 
-| Runtime | Language | Use Case | Gateway | Probe |
-|---------|----------|----------|---------|-------|
-| **OpenClaw** | TypeScript/Node.js | Full-featured AI assistant platform | 18900 | HTTP |
-| **NanoClaw** | TypeScript/Node.js | Lightweight secure personal assistant | 19000 | TCP |
-| **ZeroClaw** | Rust | High-performance agent runtime | 3000 | HTTP |
-| **PicoClaw** | — | Ultra-minimal serverless agent | 8080 | TCP |
-| **IronClaw** | Rust + WASM | Security/privacy-focused AI assistant | 3001 | HTTP |
-| **HermesClaw** | Python | Nous Research Hermes — tool-calling LLM agent | 8642 | HTTP |
-| **K8sOps** | Python/Go | Companion Claw for claw4k8s self-healing | 8800 | HTTP |
-| **Custom** | Any | Bring your own runtime | — | — |
+The **Runtime** column shows the exact value to put in `spec.runtime` on a `Claw` CR. Names ending in `claw` are k8s4claw's internal runtime type enum — they are **wrappers around upstream projects**, not forks.
+
+| `spec.runtime` | Language           | Upstream / Use Case                                                                                        | Gateway | Probe |
+| -------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- | ------- | ----- |
+| `openclaw`     | TypeScript/Node.js | Full-featured AI assistant platform (first-party)                                                          | 18900   | HTTP  |
+| `nanoclaw`     | TypeScript/Node.js | Lightweight secure personal assistant (first-party)                                                        | 19000   | TCP   |
+| `zeroclaw`     | Rust               | High-performance agent runtime (first-party)                                                               | 3000    | HTTP  |
+| `picoclaw`     | —                  | Ultra-minimal serverless agent (first-party)                                                               | 8080    | TCP   |
+| `ironclaw`     | Rust + WASM        | Security/privacy-focused AI assistant (first-party)                                                        | 3001    | HTTP  |
+| `hermesclaw`   | Python             | Wrapper for [Nous Research Hermes](https://huggingface.co/NousResearch) — OSS tool-calling LLM family      | 8642    | HTTP  |
+| `k8sops`       | Go                 | Companion Claw runtime used by [claw4k8s](docs/plans/2026-04-19-claw4k8s-design.md) for self-healing       | 8800    | HTTP  |
+| `custom`       | Any                | Bring your own runtime image                                                                               | —       | —     |
 
 ## Quick Start
 


### PR DESCRIPTION
## Problem

Reader feedback: the Supported Runtimes table listed \"**HermesClaw**\" as a runtime name, but searching GitHub for \"HermesClaw\" returns nothing — Nous Research doesn't use that name for their Hermes project.

## Fix

- Rename table header \`Runtime\` → \`spec.runtime\` so it's clear these are operator-internal RuntimeType enum values
- Mark first-party runtimes explicitly as \"(first-party)\"
- Label \`hermesclaw\` as a wrapper for [Nous Research Hermes](https://huggingface.co/NousResearch) with a working link
- Fix K8sOps language: Python/Go → Go (the Companion Claw binary is Go-only)
- Leading paragraph now says \`*claw\` names are the operator's type enum, not forks
- Pad separator row to satisfy markdownlint MD060

🤖 Generated with [Claude Code](https://claude.ai/code)