### PR TITLE
docs(readme): link hermesclaw to real nousresearch/hermes-agent repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The **Runtime** column shows the exact value to put in `spec.runtime` on a `Claw
 | `zeroclaw`     | Rust               | High-performance agent runtime (first-party)                                                               | 3000    | HTTP  |
 | `picoclaw`     | —                  | Ultra-minimal serverless agent (first-party)                                                               | 8080    | TCP   |
 | `ironclaw`     | Rust + WASM        | Security/privacy-focused AI assistant (first-party)                                                        | 3001    | HTTP  |
-| `hermesclaw`   | Python             | Wrapper for [Nous Research Hermes](https://huggingface.co/NousResearch) — OSS tool-calling LLM family      | 8642    | HTTP  |
+| `hermesclaw`   | Python             | Runs [nousresearch/hermes-agent](https://github.com/nousresearch/hermes-agent) via a RuntimeAdapter        | 8642    | HTTP  |
 | `k8sops`       | Go                 | Companion Claw runtime used by [claw4k8s](docs/plans/2026-04-19-claw4k8s-design.md) for self-healing       | 8800    | HTTP  |
 | `custom`       | Any                | Bring your own runtime image                                                                               | —       | —     |
 


### PR DESCRIPTION
Fixes the upstream link I got wrong in PR #15. Real upstream is https://github.com/nousresearch/hermes-agent (matches the image ref `ghcr.io/nousresearch/hermes-agent`), not the HuggingFace model org.

🤖 Generated with [Claude Code](https://claude.ai/code)