### PR TITLE
feat(helm): add Companion Claw RBAC and bump chart to 0.3.0

### DIFF
--- a/charts/k8s4claw/Chart.yaml
+++ b/charts/k8s4claw/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k8s4claw
 description: Kubernetes operator for managing Claw AI agent runtimes
 type: application
-version: 0.2.1
-appVersion: "0.2.1"
+version: 0.3.0
+appVersion: "0.3.0"
 kubeVersion: ">=1.28.0-0"
 home: https://github.com/Prismer-AI/k8s4claw
 maintainers:

--- a/charts/k8s4claw/templates/companion-rbac.yaml
+++ b/charts/k8s4claw/templates/companion-rbac.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.companion.rbac.create }}
+# Companion Claw RBAC — namespace-scoped, read-only diagnostics + escalation status writes.
+# Created per-namespace when users deploy a Companion Claw (runtime: k8sops).
+# The Companion Claw has NO write access to Claw CRs — only ClawOpsEscalation/status.
+{{- range .Values.companion.rbac.namespaces }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.companion.serviceAccountName }}
+  namespace: {{ . }}
+  labels:
+    {{- include "k8s4claw.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: companion
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $.Values.companion.serviceAccountName }}
+  namespace: {{ . }}
+  labels:
+    {{- include "k8s4claw.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: companion
+rules:
+  # Read-only: diagnostics
+  - apiGroups: [""]
+    resources: ["pods", "services", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["claw.prismer.ai"]
+    resources: ["claws", "clawopsescalations"]
+    verbs: ["get", "list", "watch"]
+  # Only write: Escalation status (analysis + proposed action)
+  - apiGroups: ["claw.prismer.ai"]
+    resources: ["clawopsescalations/status"]
+    verbs: ["update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $.Values.companion.serviceAccountName }}
+  namespace: {{ . }}
+  labels:
+    {{- include "k8s4claw.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: companion
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.companion.serviceAccountName }}
+    namespace: {{ . }}
+roleRef:
+  kind: Role
+  name: {{ $.Values.companion.serviceAccountName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/charts/k8s4claw/values.yaml
+++ b/charts/k8s4claw/values.yaml
@@ -45,6 +45,22 @@ monitoring:
   prometheusRule:
     enabled: true
 
+# -- Companion Claw (claw4k8s) RBAC for autonomous ops.
+# Creates namespace-scoped ServiceAccount, Role, and RoleBinding
+# for the Companion Claw runtime (k8sops). The Companion has
+# read-only access to diagnostics and can only write to
+# ClawOpsEscalation/status (no Claw CR writes).
+companion:
+  rbac:
+    create: false
+    # Namespaces where Companion Claw RBAC should be created.
+    # Typically the namespace(s) where your Claw agents run.
+    namespaces: []
+    # namespaces:
+    #   - default
+    #   - ai-agents
+  serviceAccountName: claw4k8s-companion
+
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/docs/articles/devto-introducing-k8s4claw.md
+++ b/docs/articles/devto-introducing-k8s4claw.md
@@ -1,14 +1,14 @@
 ---
 title: "k8s4claw: A Kubernetes Operator for Managing AI Agent Runtimes"
 published: false
-description: "How we built a Kubernetes operator that manages heterogeneous AI agent runtimes with a single CRD — complete with IPC bus, auto-updates, and circuit breaker rollbacks."
+description: "An open-source Kubernetes operator that deploys heterogeneous AI agent runtimes with a single CRD — IPC bus with WAL/DLQ, auto-updates with circuit-breaker rollbacks, and a Go SDK."
 tags: kubernetes, go, ai, opensource
 cover_image:
 ---
 
-Every AI agent framework has its own deployment story. OpenAI's assistants run one way, Claude-based agents another, open-source frameworks yet another. If you're running multiple agents in production on Kubernetes, you end up writing the same boilerplate over and over: secret management, persistent storage, graceful updates, inter-service communication, observability.
+Every AI agent framework has its own deployment story. Claude-based assistants run one way, OpenAI agents another, security-focused runtimes yet another. If you run more than one on Kubernetes, you end up writing the same boilerplate over and over: secret management, persistent storage, graceful updates, inter-service messaging, observability.
 
-**k8s4claw** wraps all of this into a single Kubernetes operator. One CRD, any runtime, production-ready from day one.
+**k8s4claw** is an open-source Kubernetes operator that wraps all of this behind a single CRD. You describe *what* the agent is, it handles *how* it runs.
 
 ```yaml
 apiVersion: claw.prismer.ai/v1alpha1
@@ -24,27 +24,28 @@ spec:
       name: llm-api-keys
 ```
 
-That's it. The operator handles StatefulSet creation, PVC lifecycle, credential injection, health probes, network policies, and more.
+The operator reconciles this into a StatefulSet, headless Service, ConfigMap, ServiceAccount, PodDisruptionBudget, and optionally NetworkPolicy and Ingress. When you add a channel (Slack, Discord, Webhook), it also wires up sidecars and a local message bus.
 
-In this post I'll walk through the architecture, show you how to get started, and explain the design decisions behind the IPC bus, auto-update controller, and runtime adapter system.
+This post walks through the architecture, shows how to get it running locally, and explains the design decisions behind the IPC bus, the auto-update controller, and the runtime adapter system.
 
 ---
 
 ## The Problem
 
-We were running 5 different AI agent runtimes on Kubernetes:
+We had several agent runtimes in flight at once — different languages, different process models, different resource profiles:
 
 | Runtime | Language | Use Case |
 |---------|----------|----------|
 | OpenClaw | TypeScript/Node.js | Full-featured AI assistant |
 | NanoClaw | TypeScript/Node.js | Lightweight personal assistant |
 | ZeroClaw | Rust | High-performance agent |
-| PicoClaw | — | Ultra-minimal serverless |
+| PicoClaw | Go | Ultra-minimal serverless |
 | IronClaw | Rust + WASM | Security-focused agent |
+| HermesClaw | Python | Conversational with tool use |
 
-Each had its own Helm chart, its own sidecar configuration, its own update strategy. Adding a Slack channel to an agent meant editing 4 different files. Rotating credentials meant touching every deployment. Rolling back a bad update was manual and terrifying.
+Each had its own Helm chart, sidecar layout, and update strategy. Adding a Slack channel meant editing several files. Rotating credentials meant touching every deployment. Rolling back a bad update was a manual process.
 
-We needed a single control plane.
+We wanted one control plane for all of them.
 
 ---
 
@@ -55,7 +56,7 @@ graph TB
     subgraph "Kubernetes Cluster"
         OP[k8s4claw Operator]
 
-        subgraph "Claw Pod"
+        subgraph "Claw Pod (with channels)"
             INIT["claw-init"]
             RT["Runtime Container"]
             IPC["IPC Bus Sidecar"]
@@ -82,12 +83,14 @@ graph TB
     CH <-->|API| EXT
 ```
 
-The operator watches `Claw` custom resources and reconciles a full stack of Kubernetes objects: StatefulSet, Service, ConfigMap, ServiceAccount, PDB, NetworkPolicy, and optionally Ingress. Each agent pod contains:
+The operator watches `Claw` custom resources and reconciles a full stack of Kubernetes objects. A minimal agent (no channels, no persistence) gets just the runtime container plus `claw-init`. If you declare any channels in `spec.channels`, the operator also injects:
 
-1. **claw-init** — init container that merges runtime config
-2. **Runtime container** — the actual AI agent
-3. **IPC Bus sidecar** — message routing with WAL-backed delivery
-4. **Channel sidecar(s)** — Slack, webhook, or custom integrations
+1. **claw-init** — an init container that merges default runtime config with any user overrides before the runtime starts.
+2. **Runtime container** — the actual AI agent binary.
+3. **IPC Bus sidecar** (only when channels are present) — a WAL-backed message router that sits between the runtime and the channel sidecars.
+4. **Channel sidecar(s)** — one per referenced `ClawChannel` (Slack, Discord, Webhook today).
+
+There is a second CRD, `ClawChannel`, that describes how to connect to an external system. Channels are defined once and referenced by many Claws.
 
 ---
 
@@ -95,8 +98,9 @@ The operator watches `Claw` custom resources and reconciles a full stack of Kube
 
 ### Prerequisites
 
-- Kubernetes 1.28+ (or [kind](https://kind.sigs.k8s.io/) for local dev)
-- Go 1.23+
+- Kubernetes 1.28+ (or [kind](https://kind.sigs.k8s.io/) for local development)
+- Go 1.25+
+- `controller-gen` (`go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest`) — needed by `make install`
 
 ### Install and run
 
@@ -104,21 +108,21 @@ The operator watches `Claw` custom resources and reconciles a full stack of Kube
 git clone https://github.com/Prismer-AI/k8s4claw.git
 cd k8s4claw
 
-# Install CRDs
+# Install CRDs into the active cluster
 make install
 
-# Run operator locally
-make run
+# Run the operator locally against your current kubeconfig.
+# --disable-webhooks lets you skip cert-manager setup during local dev.
+# In-cluster deployments should leave webhooks enabled.
+go run ./cmd/operator/ --disable-webhooks
 ```
 
 ### Create your first agent
 
 ```bash
-# Create a secret for your LLM API keys
 kubectl create secret generic llm-api-keys \
   --from-literal=ANTHROPIC_API_KEY=sk-ant-xxx
 
-# Deploy an agent
 cat <<EOF | kubectl apply -f -
 apiVersion: claw.prismer.ai/v1alpha1
 kind: Claw
@@ -142,7 +146,6 @@ spec:
       mountPath: /workspace
 EOF
 
-# Watch it come up
 kubectl get claw my-agent -w
 ```
 
@@ -163,7 +166,7 @@ spec:
     appId: "A0123456789"
 ```
 
-Reference it in your Claw:
+Reference it from your `Claw`:
 
 ```yaml
 spec:
@@ -172,13 +175,13 @@ spec:
       mode: bidirectional
 ```
 
-The operator automatically injects a Slack sidecar into the pod and wires it through the IPC bus.
+On the next reconcile the operator injects a Slack sidecar, spins up the IPC bus sidecar, and wires them together. The runtime container does not need to know anything about Slack — it just talks to the bus.
 
 ---
 
 ## Deep Dive: The IPC Bus
 
-The most interesting piece of k8s4claw is the IPC bus. It's a native Kubernetes sidecar (init container with `restartPolicy: Always`) that routes JSON messages between channel sidecars and the AI runtime.
+The IPC bus is the most interesting piece of k8s4claw. It is a Kubernetes [native sidecar](https://kubernetes.io/blog/2023/08/25/native-sidecar-containers/) (an init container with `restartPolicy: Always`) that routes JSON messages between channel sidecars and the agent runtime.
 
 ```
 Channel Sidecar ──UDS──► IPC Bus ──Bridge──► Runtime Container
@@ -190,64 +193,66 @@ Channel Sidecar ──UDS──► IPC Bus ──Bridge──► Runtime Contain
 
 ### Why not just HTTP?
 
-We tried. The problem is reliability. When a Slack message comes in and the runtime is temporarily overloaded, you need somewhere to buffer it. When the runtime crashes mid-response, you need to redeliver. When a channel sidecar falls behind, you need backpressure — not dropped messages.
+We tried. The problem is reliability. When a Slack event arrives while the runtime is overloaded, you need somewhere to buffer it. If the runtime crashes mid-response, you need to redeliver. When a channel sidecar falls behind, you need backpressure instead of dropped messages.
 
-The IPC bus solves this with three mechanisms:
+Three mechanisms do the work:
 
-**1. Write-Ahead Log (WAL)** — Every message is appended to a WAL on emptyDir before delivery. If the bus crashes, unacknowledged messages are replayed on recovery. Periodic compaction prevents unbounded growth.
+**1. Write-Ahead Log (WAL)** — Every inbound message is appended to a WAL on `emptyDir` before delivery. On restart, unacknowledged messages are replayed. Periodic compaction keeps the file bounded.
 
-**2. Dead Letter Queue (DLQ)** — Messages that exceed retry limits land in a BoltDB-backed DLQ. They're preserved for debugging, not silently dropped.
+**2. Dead Letter Queue (DLQ)** — Messages that exceed the retry limit land in a BoltDB-backed DLQ instead of being dropped silently. You can inspect them later.
 
-**3. Ring Buffer with Backpressure** — A fixed-size ring buffer with configurable high/low watermarks. When the buffer hits the high watermark (default 80%), the bus sends a `slow_down` signal upstream. When it drains to the low watermark (30%), it sends `resume`.
+**3. Ring buffer with backpressure** — A fixed-size circular buffer with configurable high/low watermarks. Crossing the high watermark sends `slow_down` upstream; draining to the low watermark sends `resume`.
 
-### Bridge Protocols
+### Bridge protocols
 
-Different runtimes speak different protocols. The IPC bus abstracts this behind a `RuntimeBridge` interface:
+Different runtimes speak different wire protocols. The bus abstracts this behind a `RuntimeBridge` interface:
 
 | Runtime | Bridge | Protocol |
 |---------|--------|----------|
 | OpenClaw | WebSocket | Full-duplex JSON over WS |
-| PicoClaw | TCP | Length-prefix framed |
 | NanoClaw | UDS | Length-prefix framed |
 | ZeroClaw | SSE | HTTP POST + Server-Sent Events |
+| PicoClaw | TCP | Length-prefix framed |
 
-Adding a new protocol means implementing one interface:
+Here is the actual interface ([`internal/ipcbus/bridge.go`](https://github.com/Prismer-AI/k8s4claw/blob/main/internal/ipcbus/bridge.go)):
 
 ```go
 type RuntimeBridge interface {
-    Start(ctx context.Context) error
-    Send(ctx context.Context, msg Message) error
-    Receive(ctx context.Context) (Message, error)
+    Connect(ctx context.Context) error
+    Send(ctx context.Context, msg *Message) error
+    Receive(ctx context.Context) (<-chan *Message, error)
     Close() error
 }
 ```
+
+Adding a new transport means implementing these four methods.
 
 ---
 
 ## Deep Dive: Auto-Update Controller
 
-The auto-update controller polls OCI registries on a cron schedule, finds new versions matching a semver constraint, and performs health-verified rollouts with automatic rollback.
+The auto-update controller polls OCI registries on a cron schedule, filters new tags by a semver constraint, and performs health-verified rollouts with automatic rollback.
 
 ```yaml
 spec:
   autoUpdate:
     enabled: true
     versionConstraint: "^1.x"
-    schedule: "0 3 * * *"       # Check at 3am daily
+    schedule: "0 3 * * *"
     healthTimeout: "10m"
     maxRollbacks: 3
 ```
 
 ### How it works
 
-1. **Poll** — On each cron tick, list tags from the OCI registry and filter by semver constraint
-2. **Initiate** — Set target-image annotation and enter `HealthCheck` phase
-3. **Health check** — Poll StatefulSet readiness every 15 seconds
-4. **Success** — All replicas ready → update status, clear annotations, requeue at next cron
-5. **Timeout** — Health timeout exceeded → rollback to previous version
-6. **Circuit breaker** — After N consecutive rollbacks, stop trying (operator event + Prometheus metric)
+1. **Poll** — on each cron tick, list tags from the registry and filter by the semver constraint.
+2. **Initiate** — annotate the `Claw` with the target image and transition into the `HealthCheck` phase.
+3. **Health check** — watch the StatefulSet readiness until all replicas are ready or the timeout fires.
+4. **Success** — update status, clear the annotation, schedule the next cron tick.
+5. **Timeout** — roll back to the previous image.
+6. **Circuit breaker** — after N consecutive rollbacks, stop trying and emit an event plus a Prometheus metric.
 
-The state machine lives entirely in annotations and status conditions, so it survives operator restarts:
+The state machine lives in annotations and status conditions, so it survives operator restarts:
 
 ```go
 phase := claw.Annotations["claw.prismer.ai/update-phase"]
@@ -258,7 +263,7 @@ if phase == "HealthCheck" {
 
 ### Version history
 
-Every update attempt is recorded:
+Every attempt is recorded:
 
 ```yaml
 status:
@@ -283,12 +288,20 @@ Each runtime is a Go struct implementing `RuntimeAdapter`:
 
 ```go
 type RuntimeAdapter interface {
-    RuntimeBuilder    // PodTemplate, probes, config
-    RuntimeValidator  // Validate, ValidateUpdate
+    // Pod shape
+    PodTemplate(claw *v1alpha1.Claw) *corev1.PodTemplateSpec
+    HealthProbe(claw *v1alpha1.Claw) *corev1.Probe
+    ReadinessProbe(claw *v1alpha1.Claw) *corev1.Probe
+    DefaultConfig() *RuntimeConfig
+    GracefulShutdownSeconds() int32
+
+    // Spec validation
+    Validate(ctx context.Context, spec *v1alpha1.ClawSpec) field.ErrorList
+    ValidateUpdate(ctx context.Context, oldSpec, newSpec *v1alpha1.ClawSpec) field.ErrorList
 }
 ```
 
-Adding a new runtime takes ~100 lines:
+A new adapter typically lives in a single file of ~100 lines. The shared `BuildPodTemplate` helper handles init containers, volume mounts, security context, and environment variables, so the adapter only declares what is actually different:
 
 ```go
 type MyRuntimeAdapter struct{}
@@ -301,91 +314,125 @@ func (a *MyRuntimeAdapter) PodTemplate(claw *v1alpha1.Claw) *corev1.PodTemplateS
         // ...
     })
 }
+// plus HealthProbe, ReadinessProbe, DefaultConfig, GracefulShutdownSeconds,
+// Validate, ValidateUpdate
 ```
 
-The shared `BuildPodTemplate` handles the common concerns — init containers, volume mounts, security context, environment variables — while each adapter only specifies what's different.
-
-Validation is per-runtime too. OpenClaw and IronClaw require credentials (they talk to LLM APIs). ZeroClaw and PicoClaw don't. All runtimes share persistence update validation (storage class immutable, PVC size expansion-only).
+Validation is per-runtime on purpose. OpenClaw and IronClaw require credentials because they call LLM APIs. ZeroClaw and PicoClaw permit credential-less operation. HermesClaw rejects `spec.channels` because it brings its own gateway. NanoClaw currently has no update-time persistence checks. The point is each adapter owns its own rules.
 
 ---
 
 ## Go SDK
 
-For programmatic access, there's a Go SDK:
+For programmatic access there is a Go SDK ([`sdk/`](https://github.com/Prismer-AI/k8s4claw/tree/main/sdk)):
 
 ```go
-import "github.com/Prismer-AI/k8s4claw/sdk"
+import (
+    "context"
 
-client, err := sdk.NewClient()
+    "github.com/Prismer-AI/k8s4claw/sdk"
+)
 
-// Create an agent
+client, err := sdk.NewClient() // uses the ambient kubeconfig by default
+if err != nil {
+    return err
+}
+
 claw, err := client.Create(ctx, &sdk.ClawSpec{
     Runtime: sdk.OpenClaw,
     Config: &sdk.RuntimeConfig{
         Environment: map[string]string{"MODEL": "claude-sonnet-4"},
     },
 })
+if err != nil {
+    return err
+}
 
-// Watch for readiness
-err = client.WaitForReady(ctx, claw.Name, 5*time.Minute)
+// Block until the Claw reaches phase "Running" or ctx expires.
+if err := client.WaitForReady(ctx, claw); err != nil {
+    return err
+}
 ```
 
-There's also a channel SDK for building custom sidecars:
+There is also a channel SDK for writing custom sidecars:
 
 ```go
-import "github.com/Prismer-AI/k8s4claw/sdk/channel"
+import (
+    "context"
+    "encoding/json"
 
-client, err := channel.NewClient(
+    "github.com/Prismer-AI/k8s4claw/sdk/channel"
+)
+
+client, err := channel.Connect(ctx,
+    channel.WithChannelName("my-channel"), // or set CHANNEL_NAME env
     channel.WithSocketPath("/var/run/claw/bus.sock"),
     channel.WithBufferSize(100),
 )
+if err != nil {
+    return err
+}
+defer client.Close()
 
-// Send a message to the runtime
-err = client.Send(ctx, channel.Message{
-    Type:    "user_message",
-    Payload: json.RawMessage(`{"text": "Hello"}`),
-})
+// Send a message to the runtime.
+if err := client.Send(ctx, json.RawMessage(`{"text":"Hello"}`)); err != nil {
+    return err
+}
 
-// Receive runtime responses
-msg, err := client.Receive(ctx)
+// Receive returns a channel of *InboundMessage.
+inbox, err := client.Receive(ctx)
+if err != nil {
+    return err
+}
+for msg := range inbox {
+    // handle msg
+    _ = msg
+}
 ```
 
 ---
 
 ## Testing Strategy
 
-We aimed for 80%+ coverage across all packages, and achieved it:
+The core packages all sit above 80% statement coverage as of the current release, checked in CI on every PR:
 
 | Package | Coverage |
 |---------|----------|
-| internal/webhook | 97.6% |
-| internal/runtime | 94.0% |
-| internal/registry | 85.7% |
-| sdk | 83.1% |
-| internal/controller | 81.6% |
-| sdk/channel | 81.5% |
-| internal/ipcbus | 80.8% |
+| `internal/webhook` | 97.6% |
+| `internal/runtime` | 94%+ |
+| `internal/registry` | 86%+ |
+| `sdk` | 83%+ |
+| `internal/controller` | 81%+ |
+| `sdk/channel` | 81%+ |
+| `internal/ipcbus` | 80%+ |
+
+CI enforces a total-coverage threshold; per-package floors are maintained by convention and visible in the coverage report attached to each run.
 
 The testing pyramid:
 
-- **Unit tests** — pure functions, table-driven, `t.Parallel()` everywhere
-- **Fake client tests** — `fake.NewClientBuilder()` for controller logic without a real cluster
-- **envtest integration tests** — real etcd + API server for webhook validation and reconcile loops
+- **Unit tests** — pure functions, table-driven, `t.Parallel()` everywhere.
+- **Fake-client tests** — `fake.NewClientBuilder()` for controller logic without a real cluster.
+- **envtest integration tests** — real etcd + API server for webhook validation and reconcile loops.
 
-For the auto-update controller, we used dependency injection with `Clock` and `TagLister` interfaces to make time-dependent and registry-dependent code fully testable without network calls.
+The auto-update controller uses dependency injection via `Clock` and `TagLister` interfaces so time-dependent and registry-dependent code is fully testable with no network calls.
+
+---
+
+## What's Not Done Yet
+
+Worth being honest about:
+
+- **`custom` runtime type** is present in the CRD enum but no adapter is registered. If you want a runtime that is not in the built-in list today, you fork and add an adapter.
+- **HermesClaw** does not yet integrate with the k8s4claw channel sidecars — it uses its own gateway.
+- **Local operator runs** need `--disable-webhooks` unless you've set up cert-manager or your own TLS. In-cluster deployments via the Helm chart handle this for you.
+- **CRD surface is larger than just `Claw`** — `ClawChannel`, `ClawSelfConfig`, and related types are part of the contract. "Single CRD" is a simplification; "small, focused set of CRDs" is closer to the truth.
 
 ---
 
 ## What's Next
 
-k8s4claw is open source under Apache-2.0. We're looking for contributors! Here are some good starting points:
-
-- [Add credential validation to ZeroClaw/PicoClaw](https://github.com/Prismer-AI/k8s4claw/issues/1) — Easy, single file
-- [Add Helm chart](https://github.com/Prismer-AI/k8s4claw/issues/2) — Medium
-- [Add Discord channel sidecar](https://github.com/Prismer-AI/k8s4claw/issues/3) — Medium
-- [Boost test coverage to 85%+](https://github.com/Prismer-AI/k8s4claw/issues/4) — Medium
-- [Add local dev setup guide](https://github.com/Prismer-AI/k8s4claw/issues/5) — Easy
+k8s4claw is open source under Apache-2.0. If you want to help, a good starting point is [Issue #4: add snapshot and PDB envtest coverage](https://github.com/Prismer-AI/k8s4claw/issues/4). Browse the [issue tracker](https://github.com/Prismer-AI/k8s4claw/issues) for more.
 
 **GitHub**: [github.com/Prismer-AI/k8s4claw](https://github.com/Prismer-AI/k8s4claw)
 
-If you're running AI agents on Kubernetes and tired of managing the infrastructure around them, give k8s4claw a try. Star the repo if it's useful, and open an issue if it isn't — we want to hear both.
+If you run AI agents on Kubernetes and you're tired of maintaining the plumbing around them, give it a try. Star the repo if it helps, and open an issue if something is off — both signals are useful.


### PR DESCRIPTION
## Summary

- Add namespace-scoped RBAC template for Companion Claw (`k8sops` runtime): ServiceAccount + Role + RoleBinding per configured namespace
- Companion has read-only diagnostics access + ClawOpsEscalation/status writes only (no Claw CR writes — enforces intent annotation security boundary)
- New `companion.*` values section (opt-in, disabled by default)
- Chart version 0.2.1 → 0.3.0

## Test plan

- [x] `helm lint charts/k8s4claw/` passes
- [x] `helm template` renders correctly with default values (companion disabled)
- [x] `helm template --set companion.rbac.create=true --set 'companion.rbac.namespaces={default,ai-agents}'` generates 6 resources (SA + Role + RoleBinding × 2 namespaces)

🤖 Generated with [Claude Code](https://claude.ai/code)