### PR TITLE
ci: add ci-gate aggregate so docs-only PRs are not blocked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,3 +190,31 @@ jobs:
           if [ "$failed" -eq 1 ]; then
             exit 1
           fi
+
+  # Aggregate gate for branch protection.
+  #
+  # Set this single job as the sole required status check on main.
+  # It passes when all applicable jobs either succeeded or were correctly
+  # skipped (e.g., docs-only PRs skip Go jobs). It fails if any required
+  # job failed, was cancelled, or errored.
+  #
+  # This lets docs-only PRs merge without admin override while still
+  # failing fast on any real regression.
+  ci-gate:
+    needs: [changes, lint, test, build, verify-codegen, docker-build, govulncheck, coverage-gate, dco]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all required jobs passed or were skipped
+        run: |
+          # Any failure or cancellation in a dependency fails the gate.
+          # 'skipped' is acceptable (path-filtered jobs on docs-only PRs).
+          results='${{ toJSON(needs) }}'
+          echo "needs results: $results"
+          failed=$(echo "$results" | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key')
+          if [ -n "$failed" ]; then
+            echo "::error::One or more required jobs failed or were cancelled:"
+            echo "$failed"
+            exit 1
+          fi
+          echo "All required jobs passed or were correctly skipped."


### PR DESCRIPTION
## Summary

Adds a single `ci-gate` job that aggregates the status of all other jobs so branch protection on `main` can require one check instead of four path-filtered ones.

### Problem

`main` currently requires `[lint, test, build, verify-codegen]`. These jobs are correctly path-filtered (`if: needs.changes.outputs.go == 'true'`) so they SKIP on docs-only PRs. But GitHub treats SKIPPED required checks as "not yet passed", which BLOCKS the PR from merging. We hit this twice this week (PRs #17, #18) and had to `--admin` merge.

### Fix

`ci-gate` depends on all real jobs, runs with `if: always()`, and parses `needs.*.result`. It fails only on `failure` or `cancelled`; `skipped` is acceptable.

### Required follow-up (manual, cannot be done in this PR)

After merge, update GitHub branch protection on `main`:
- **Remove** required status checks: `lint`, `test`, `build`, `verify-codegen`
- **Add** required status check: `ci-gate`

Until that switch, `ci-gate` runs but isn't enforced — so this PR does not regress any safety, it just unblocks the path.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `needs:` list matches all job names in the workflow
- [x] `jq` expression handles `result in [success, skipped, failure, cancelled]`
- [ ] On merge + protection update: a docs-only PR merges without `--admin`
- [ ] On merge + protection update: a PR that breaks a Go test is BLOCKED (existing behavior)

🤖 Generated with [Claude Code](https://claude.ai/code)