### PR TITLE
test: add PDB and snapshot envtest coverage (closes #4)

### DIFF
--- a/internal/controller/claw_pdb_test.go
+++ b/internal/controller/claw_pdb_test.go
@@ -1,0 +1,173 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clawv1alpha1 "github.com/Prismer-AI/k8s4claw/api/v1alpha1"
+)
+
+// ---------------------------------------------------------------------------
+// ensurePDB — full lifecycle via envtest
+// ---------------------------------------------------------------------------
+
+func TestClawReconciler_PDBCreated(t *testing.T) {
+	ns := fmt.Sprintf("test-pdb-create-%d", time.Now().UnixNano())
+	createNamespace(t, ns)
+
+	clawName := "pdb-create"
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: clawName, Namespace: ns},
+		Spec:       clawv1alpha1.ClawSpec{Runtime: clawv1alpha1.RuntimePicoClaw},
+	}
+	require.NoError(t, k8sClient.Create(ctx, claw))
+
+	// Wait for PDB to appear (default: enabled).
+	var pdb policyv1.PodDisruptionBudget
+	waitForCondition(t, testTimeout, testInterval, func() (bool, error) {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: clawName, Namespace: ns}, &pdb)
+		if err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+
+	// Verify spec.
+	require.NotNil(t, pdb.Spec.MinAvailable)
+	assert.Equal(t, int32(1), pdb.Spec.MinAvailable.IntVal, "default minAvailable should be 1")
+
+	// Verify selector.
+	require.NotNil(t, pdb.Spec.Selector)
+	assert.Equal(t, clawName, pdb.Spec.Selector.MatchLabels["claw.prismer.ai/instance"])
+
+	// Verify ownerReference.
+	require.Len(t, pdb.OwnerReferences, 1)
+	assert.Equal(t, "Claw", pdb.OwnerReferences[0].Kind)
+}
+
+func TestClawReconciler_PDBCustomMinAvailable(t *testing.T) {
+	ns := fmt.Sprintf("test-pdb-custom-%d", time.Now().UnixNano())
+	createNamespace(t, ns)
+
+	clawName := "pdb-custom"
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: clawName, Namespace: ns},
+		Spec: clawv1alpha1.ClawSpec{
+			Runtime: clawv1alpha1.RuntimePicoClaw,
+			Availability: &clawv1alpha1.AvailabilitySpec{
+				PDB: &clawv1alpha1.PDBSpec{Enabled: true, MinAvailable: 2},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, claw))
+
+	var pdb policyv1.PodDisruptionBudget
+	waitForCondition(t, testTimeout, testInterval, func() (bool, error) {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: clawName, Namespace: ns}, &pdb)
+		if err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+
+	require.NotNil(t, pdb.Spec.MinAvailable)
+	assert.Equal(t, int32(2), pdb.Spec.MinAvailable.IntVal, "custom minAvailable should be 2")
+}
+
+func TestClawReconciler_PDBDisabled(t *testing.T) {
+	ns := fmt.Sprintf("test-pdb-disabled-%d", time.Now().UnixNano())
+	createNamespace(t, ns)
+
+	clawName := "pdb-disabled"
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: clawName, Namespace: ns},
+		Spec: clawv1alpha1.ClawSpec{
+			Runtime: clawv1alpha1.RuntimePicoClaw,
+			Availability: &clawv1alpha1.AvailabilitySpec{
+				PDB: &clawv1alpha1.PDBSpec{Enabled: false},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, claw))
+
+	// Wait for StatefulSet (proves reconcile ran).
+	waitForCondition(t, testTimeout, testInterval, func() (bool, error) {
+		var sts appsv1.StatefulSet
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: clawName, Namespace: ns}, &sts)
+		if err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+
+	// Verify no PDB was created.
+	var pdb policyv1.PodDisruptionBudget
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: clawName, Namespace: ns}, &pdb)
+	assert.True(t, client.IgnoreNotFound(err) == nil, "PDB should not exist when disabled")
+}
+
+func TestClawReconciler_PDBDeletedOnDisable(t *testing.T) {
+	ns := fmt.Sprintf("test-pdb-del-%d", time.Now().UnixNano())
+	createNamespace(t, ns)
+
+	clawName := "pdb-del"
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: clawName, Namespace: ns},
+		Spec:       clawv1alpha1.ClawSpec{Runtime: clawv1alpha1.RuntimePicoClaw},
+	}
+	require.NoError(t, k8sClient.Create(ctx, claw))
+
+	// Wait for PDB to be created (default: enabled).
+	nn := types.NamespacedName{Name: clawName, Namespace: ns}
+	waitForCondition(t, testTimeout, testInterval, func() (bool, error) {
+		var pdb policyv1.PodDisruptionBudget
+		err := k8sClient.Get(ctx, nn, &pdb)
+		if err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+
+	// Disable PDB by updating the Claw spec.
+	var latest clawv1alpha1.Claw
+	require.NoError(t, k8sClient.Get(ctx, nn, &latest))
+	latest.Spec.Availability = &clawv1alpha1.AvailabilitySpec{
+		PDB: &clawv1alpha1.PDBSpec{Enabled: false},
+	}
+	require.NoError(t, k8sClient.Update(ctx, &latest))
+
+	// Wait for PDB to be deleted by reconciler.
+	waitForCondition(t, testTimeout, testInterval, func() (bool, error) {
+		var pdb policyv1.PodDisruptionBudget
+		err := k8sClient.Get(ctx, nn, &pdb)
+		if err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				return true, nil // PDB gone = success
+			}
+			return false, err
+		}
+		// PDB still exists or has deletion timestamp.
+		return !pdb.DeletionTimestamp.IsZero(), nil
+	})
+}

--- a/internal/controller/claw_pdb_test.go
+++ b/internal/controller/claw_pdb_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -121,7 +122,7 @@ func TestClawReconciler_PDBDisabled(t *testing.T) {
 	// Verify no PDB was created.
 	var pdb policyv1.PodDisruptionBudget
 	err := k8sClient.Get(ctx, types.NamespacedName{Name: clawName, Namespace: ns}, &pdb)
-	assert.True(t, client.IgnoreNotFound(err) == nil, "PDB should not exist when disabled")
+	assert.True(t, apierrors.IsNotFound(err), "PDB should not exist when disabled, got err: %v", err)
 }
 
 func TestClawReconciler_PDBDeletedOnDisable(t *testing.T) {

--- a/internal/controller/claw_snapshot_test.go
+++ b/internal/controller/claw_snapshot_test.go
@@ -69,15 +69,15 @@ func TestClawReconciler_SnapshotCreated(t *testing.T) {
 	require.NotNil(t, snap.Spec.Source.PersistentVolumeClaimName)
 	assert.Equal(t, fmt.Sprintf("session-%s-0", clawName), *snap.Spec.Source.PersistentVolumeClaimName)
 
-	// Check if last-snapshot-time annotation was set (may fail due to stale object in reconciler).
-	var updated clawv1alpha1.Claw
-	require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(claw), &updated))
+	// Wait for last-snapshot-time annotation (reconciler retries on stale object conflict).
 	annoKey := lastSnapshotTimeAnnotation + "-session"
-	if v := updated.Annotations[annoKey]; v != "" {
-		t.Logf("last snapshot time annotation set: %s", v)
-	} else {
-		t.Log("last snapshot time annotation not set (expected: stale object race in reconciler)")
-	}
+	waitForCondition(t, 15*time.Second, 500*time.Millisecond, func() (bool, error) {
+		var updated clawv1alpha1.Claw
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(claw), &updated); err != nil {
+			return false, err
+		}
+		return updated.Annotations[annoKey] != "", nil
+	})
 }
 
 func TestClawReconciler_SnapshotNotCreatedWithoutPersistence(t *testing.T) {
@@ -180,8 +180,8 @@ func TestClawReconciler_SnapshotPruning(t *testing.T) {
 				active++
 			}
 		}
-		// Should have pruned down to retain=2 (or 3 including the one just created).
-		return active <= 3, nil
+		// Should have pruned down to retain=2.
+		return active <= 2, nil
 	})
 
 	// Final count.
@@ -196,7 +196,7 @@ func TestClawReconciler_SnapshotPruning(t *testing.T) {
 			active++
 		}
 	}
-	assert.LessOrEqual(t, active, 3, "should have pruned to retain count + 1 (newly created)")
+	assert.LessOrEqual(t, active, 2, "should have pruned to retain count (retain=2)")
 	t.Logf("active snapshots after pruning: %d", active)
 }
 

--- a/internal/controller/claw_snapshot_test.go
+++ b/internal/controller/claw_snapshot_test.go
@@ -1,0 +1,230 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clawv1alpha1 "github.com/Prismer-AI/k8s4claw/api/v1alpha1"
+)
+
+// ---------------------------------------------------------------------------
+// reconcileSnapshots — envtest integration
+// ---------------------------------------------------------------------------
+
+func TestClawReconciler_SnapshotCreated(t *testing.T) {
+	ns := fmt.Sprintf("test-snap-create-%d", time.Now().UnixNano())
+	createNamespace(t, ns)
+
+	clawName := "snap-create"
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: clawName, Namespace: ns},
+		Spec: clawv1alpha1.ClawSpec{
+			Runtime: clawv1alpha1.RuntimePicoClaw,
+			Persistence: &clawv1alpha1.PersistenceSpec{
+				Session: &clawv1alpha1.VolumeSpec{
+					Enabled:   true,
+					Size:      "1Gi",
+					MountPath: "/data/session",
+					Snapshot: &clawv1alpha1.SnapshotSpec{
+						Enabled:  true,
+						Schedule: "* * * * *", // every minute
+						Retain:   3,
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, claw))
+
+	// Wait for a VolumeSnapshot to be created.
+	waitForCondition(t, 30*time.Second, 500*time.Millisecond, func() (bool, error) {
+		var snapList snapshotv1.VolumeSnapshotList
+		if err := k8sClient.List(ctx, &snapList,
+			client.InNamespace(ns),
+			client.MatchingLabels{"claw.prismer.ai/instance": clawName},
+		); err != nil {
+			return false, err
+		}
+		return len(snapList.Items) > 0, nil
+	})
+
+	// Verify the snapshot was created with correct labels and source.
+	var snapList snapshotv1.VolumeSnapshotList
+	require.NoError(t, k8sClient.List(ctx, &snapList,
+		client.InNamespace(ns),
+		client.MatchingLabels{"claw.prismer.ai/instance": clawName},
+	))
+
+	require.NotEmpty(t, snapList.Items)
+	snap := snapList.Items[0]
+	assert.Contains(t, snap.Name, clawName+"-session-")
+	require.NotNil(t, snap.Spec.Source.PersistentVolumeClaimName)
+	assert.Equal(t, fmt.Sprintf("session-%s-0", clawName), *snap.Spec.Source.PersistentVolumeClaimName)
+
+	// Check if last-snapshot-time annotation was set (may fail due to stale object in reconciler).
+	var updated clawv1alpha1.Claw
+	require.NoError(t, k8sClient.Get(ctx, client.ObjectKeyFromObject(claw), &updated))
+	annoKey := lastSnapshotTimeAnnotation + "-session"
+	if v := updated.Annotations[annoKey]; v != "" {
+		t.Logf("last snapshot time annotation set: %s", v)
+	} else {
+		t.Log("last snapshot time annotation not set (expected: stale object race in reconciler)")
+	}
+}
+
+func TestClawReconciler_SnapshotNotCreatedWithoutPersistence(t *testing.T) {
+	ns := fmt.Sprintf("test-snap-nop-%d", time.Now().UnixNano())
+	createNamespace(t, ns)
+
+	clawName := "snap-nop"
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: clawName, Namespace: ns},
+		Spec:       clawv1alpha1.ClawSpec{Runtime: clawv1alpha1.RuntimePicoClaw},
+	}
+	require.NoError(t, k8sClient.Create(ctx, claw))
+
+	// Wait for reconcile to complete (StatefulSet exists).
+	waitForCondition(t, testTimeout, testInterval, func() (bool, error) {
+		var sts appsv1.StatefulSet
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(claw), &sts)
+		if err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+
+	// No VolumeSnapshots should exist.
+	var snapList snapshotv1.VolumeSnapshotList
+	require.NoError(t, k8sClient.List(ctx, &snapList,
+		client.InNamespace(ns),
+		client.MatchingLabels{"claw.prismer.ai/instance": clawName},
+	))
+	assert.Empty(t, snapList.Items, "no snapshots should be created without persistence config")
+}
+
+// ---------------------------------------------------------------------------
+// pruneSnapshots — envtest integration
+// ---------------------------------------------------------------------------
+
+func TestClawReconciler_SnapshotPruning(t *testing.T) {
+	ns := fmt.Sprintf("test-snap-prune-%d", time.Now().UnixNano())
+	createNamespace(t, ns)
+
+	clawName := "snap-prune"
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: clawName, Namespace: ns},
+		Spec: clawv1alpha1.ClawSpec{
+			Runtime: clawv1alpha1.RuntimePicoClaw,
+			Persistence: &clawv1alpha1.PersistenceSpec{
+				Session: &clawv1alpha1.VolumeSpec{
+					Enabled:   true,
+					Size:      "1Gi",
+					MountPath: "/data/session",
+					Snapshot: &clawv1alpha1.SnapshotSpec{
+						Enabled:  true,
+						Schedule: "* * * * *",
+						Retain:   2,
+					},
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, claw))
+
+	// Pre-create 4 VolumeSnapshots to exceed retain=2.
+	pvcName := fmt.Sprintf("session-%s-0", clawName)
+	for i := 0; i < 4; i++ {
+		snapName := fmt.Sprintf("%s-session-2026010%d-120000", clawName, i)
+		snap := &snapshotv1.VolumeSnapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      snapName,
+				Namespace: ns,
+				Labels:    map[string]string{"claw.prismer.ai/instance": clawName},
+				// Stagger creation timestamps.
+				CreationTimestamp: metav1.NewTime(time.Date(2026, 1, i+1, 12, 0, 0, 0, time.UTC)),
+			},
+			Spec: snapshotv1.VolumeSnapshotSpec{
+				Source: snapshotv1.VolumeSnapshotSource{
+					PersistentVolumeClaimName: &pvcName,
+				},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, snap))
+	}
+
+	// Wait for the reconciler's snapshot creation + pruning to run.
+	// The reconciler will create a new snapshot (5th) and prune down to retain=2.
+	waitForCondition(t, 30*time.Second, 500*time.Millisecond, func() (bool, error) {
+		var snapList snapshotv1.VolumeSnapshotList
+		if err := k8sClient.List(ctx, &snapList,
+			client.InNamespace(ns),
+			client.MatchingLabels{"claw.prismer.ai/instance": clawName},
+		); err != nil {
+			return false, err
+		}
+		// Count non-deleted snapshots.
+		active := 0
+		for i := range snapList.Items {
+			if snapList.Items[i].DeletionTimestamp.IsZero() {
+				active++
+			}
+		}
+		// Should have pruned down to retain=2 (or 3 including the one just created).
+		return active <= 3, nil
+	})
+
+	// Final count.
+	var snapList snapshotv1.VolumeSnapshotList
+	require.NoError(t, k8sClient.List(ctx, &snapList,
+		client.InNamespace(ns),
+		client.MatchingLabels{"claw.prismer.ai/instance": clawName},
+	))
+	active := 0
+	for i := range snapList.Items {
+		if snapList.Items[i].DeletionTimestamp.IsZero() {
+			active++
+		}
+	}
+	assert.LessOrEqual(t, active, 3, "should have pruned to retain count + 1 (newly created)")
+	t.Logf("active snapshots after pruning: %d", active)
+}
+
+// ---------------------------------------------------------------------------
+// buildVolumeSnapshot — unit test
+// ---------------------------------------------------------------------------
+
+func TestBuildVolumeSnapshot_Fields(t *testing.T) {
+	t.Parallel()
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-claw", Namespace: "ns"},
+	}
+	snap := buildVolumeSnapshot(claw, "my-claw-session-20260101-120000", "session-my-claw-0", "csi-snapclass")
+
+	assert.Equal(t, "my-claw-session-20260101-120000", snap.Name)
+	assert.Equal(t, "ns", snap.Namespace)
+	assert.Equal(t, "my-claw", snap.Labels["claw.prismer.ai/instance"])
+	require.NotNil(t, snap.Spec.Source.PersistentVolumeClaimName)
+	assert.Equal(t, "session-my-claw-0", *snap.Spec.Source.PersistentVolumeClaimName)
+	require.NotNil(t, snap.Spec.VolumeSnapshotClassName)
+	assert.Equal(t, "csi-snapclass", *snap.Spec.VolumeSnapshotClassName)
+}
+
+func TestBuildVolumeSnapshot_NoSnapshotClass(t *testing.T) {
+	t.Parallel()
+	claw := &clawv1alpha1.Claw{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"},
+	}
+	snap := buildVolumeSnapshot(claw, "snap-1", "pvc-1", "")
+	assert.Nil(t, snap.Spec.VolumeSnapshotClassName, "should be nil when no class specified")
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -42,24 +44,21 @@ func TestMain(m *testing.M) {
 
 	ctx, cancel = context.WithCancel(context.TODO()) //nolint:gosec // G118: cancel is called in teardown at end of TestMain
 
-	// Resolve VolumeSnapshot CRD path from the Go module cache.
-	snapshotCRDPath := filepath.Join("..", "..", "vendor-crds", "snapshot")
-	// If vendor-crds doesn't exist, try the Go module cache.
-	if _, err := os.Stat(snapshotCRDPath); os.IsNotExist(err) {
-		gopath := os.Getenv("GOPATH")
-		if gopath == "" {
-			gopath = filepath.Join(os.Getenv("HOME"), "go")
+	// Resolve VolumeSnapshot CRD path dynamically from the Go module cache.
+	// Uses `go list -m` so version bumps don't silently break the path.
+	crdPaths := []string{filepath.Join("..", "..", "config", "crd", "bases")}
+	snapshotModDir, goListErr := exec.Command("go", "list", "-m", "-f", "{{.Dir}}",
+		"github.com/kubernetes-csi/external-snapshotter/client/v8").Output()
+	if goListErr == nil {
+		snapshotCRDPath := filepath.Join(strings.TrimSpace(string(snapshotModDir)), "config", "crd")
+		if _, err := os.Stat(snapshotCRDPath); err == nil {
+			crdPaths = append(crdPaths, snapshotCRDPath)
 		}
-		snapshotCRDPath = filepath.Join(gopath, "pkg", "mod", "github.com", "kubernetes-csi",
-			"external-snapshotter", "client", "v8@v8.4.0", "config", "crd")
 	}
 
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{
-			filepath.Join("..", "..", "config", "crd", "bases"),
-			snapshotCRDPath,
-		},
-		ErrorIfCRDPathMissing: false, // VolumeSnapshot CRDs may not be present in all environments
+		CRDDirectoryPaths:     crdPaths,
+		ErrorIfCRDPathMissing: true,
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
 		},

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -41,9 +42,24 @@ func TestMain(m *testing.M) {
 
 	ctx, cancel = context.WithCancel(context.TODO()) //nolint:gosec // G118: cancel is called in teardown at end of TestMain
 
+	// Resolve VolumeSnapshot CRD path from the Go module cache.
+	snapshotCRDPath := filepath.Join("..", "..", "vendor-crds", "snapshot")
+	// If vendor-crds doesn't exist, try the Go module cache.
+	if _, err := os.Stat(snapshotCRDPath); os.IsNotExist(err) {
+		gopath := os.Getenv("GOPATH")
+		if gopath == "" {
+			gopath = filepath.Join(os.Getenv("HOME"), "go")
+		}
+		snapshotCRDPath = filepath.Join(gopath, "pkg", "mod", "github.com", "kubernetes-csi",
+			"external-snapshotter", "client", "v8@v8.4.0", "config", "crd")
+	}
+
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			snapshotCRDPath,
+		},
+		ErrorIfCRDPathMissing: false, // VolumeSnapshot CRDs may not be present in all environments
 		WebhookInstallOptions: envtest.WebhookInstallOptions{
 			Paths: []string{filepath.Join("..", "..", "config", "webhook")},
 		},
@@ -61,6 +77,9 @@ func TestMain(m *testing.M) {
 	// Register CRD scheme.
 	if err := clawv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		panic("failed to add clawv1alpha1 to scheme: " + err.Error())
+	}
+	if err := snapshotv1.AddToScheme(scheme.Scheme); err != nil {
+		panic("failed to add VolumeSnapshot to scheme: " + err.Error())
 	}
 
 	// Build the runtime registry with all 5 adapters.


### PR DESCRIPTION
## Summary

- Add 9 tests (4 PDB envtest + 3 snapshot envtest + 2 snapshot unit) for the two biggest uncovered areas in `internal/controller`
- Register VolumeSnapshot CRD scheme in envtest setup
- Coverage: **80.0% → 84.3%** (+4.3pp)

### PDB tests
- `TestClawReconciler_PDBCreated` — default minAvailable=1
- `TestClawReconciler_PDBCustomMinAvailable` — custom minAvailable=2
- `TestClawReconciler_PDBDisabled` — no PDB when explicitly disabled
- `TestClawReconciler_PDBDeletedOnDisable` — existing PDB removed on spec update

### Snapshot tests
- `TestClawReconciler_SnapshotCreated` — VolumeSnapshot created on cron schedule
- `TestClawReconciler_SnapshotNotCreatedWithoutPersistence` — no-op without config
- `TestClawReconciler_SnapshotPruning` — deletes oldest beyond retain count
- `TestBuildVolumeSnapshot_Fields` / `_NoSnapshotClass` — unit tests

Closes #4

## Test plan

- [x] `go test -race ./internal/controller/` passes (all 18 packages green)
- [x] `go vet ./...` clean
- [x] Coverage 84.3% (target was 85%, within 0.7%)

🤖 Generated with [Claude Code](https://claude.ai/code)