### PR TITLE
feat(claw4k8s): add HermesGatewayClient for real LLM analysis

### DIFF
--- a/cmd/claw4k8s/llm_client.go
+++ b/cmd/claw4k8s/llm_client.go
@@ -87,7 +87,7 @@ func (c *HermesGatewayClient) Analyze(ctx context.Context, prompt string) (strin
 	if err != nil {
 		return "", "", fmt.Errorf("failed to call gateway: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/cmd/claw4k8s/llm_client.go
+++ b/cmd/claw4k8s/llm_client.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// HermesGatewayClient calls an OpenAI-compatible /v1/chat/completions endpoint.
+// Works with hermes-agent-rs hermes-gateway, Anthropic API (via gateway model
+// prefix), or any OpenAI-compatible provider.
+type HermesGatewayClient struct {
+	BaseURL string        // e.g. "http://hermes-gateway.default.svc.cluster.local:8080"
+	Model   string        // e.g. "anthropic/claude-sonnet-4-20250514"
+	APIKey  string        // optional; sent as Bearer token if non-empty
+	Timeout time.Duration // per-request timeout (default 60s)
+
+	httpClient *http.Client
+}
+
+// chat completion wire types (OpenAI-compatible subset).
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatCompletionRequest struct {
+	Model    string        `json:"model"`
+	Messages []chatMessage `json:"messages"`
+	Stream   bool          `json:"stream"`
+}
+
+type chatChoice struct {
+	Message chatMessage `json:"message"`
+}
+
+type chatCompletionResponse struct {
+	Choices []chatChoice `json:"choices"`
+}
+
+// Analyze sends the prompt to the chat completions endpoint and parses the
+// response into (analysis, action). The action JSON is expected after an
+// "ACTION:" marker or inside a ```json fenced block.
+func (c *HermesGatewayClient) Analyze(ctx context.Context, prompt string) (string, string, error) {
+	timeout := c.Timeout
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	if c.httpClient == nil {
+		c.httpClient = &http.Client{Timeout: timeout}
+	}
+
+	reqBody := chatCompletionRequest{
+		Model: c.Model,
+		Messages: []chatMessage{
+			{Role: "system", Content: companionSystemPrompt},
+			{Role: "user", Content: prompt},
+		},
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := strings.TrimRight(c.BaseURL, "/") + "/v1/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("call gateway: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return "", "", fmt.Errorf("gateway returned %d: %s", resp.StatusCode, truncate(string(respBytes), 256))
+	}
+
+	var parsed chatCompletionResponse
+	if err := json.Unmarshal(respBytes, &parsed); err != nil {
+		return "", "", fmt.Errorf("decode response: %w", err)
+	}
+	if len(parsed.Choices) == 0 {
+		return "", "", fmt.Errorf("gateway returned no choices")
+	}
+
+	content := parsed.Choices[0].Message.Content
+	analysis, action := extractAction(content)
+	return analysis, action, nil
+}
+
+// companionSystemPrompt instructs the model to produce an analysis followed by
+// a structured action JSON. Action format matches OpsIntent in the operator.
+const companionSystemPrompt = `You are an SRE assistant analyzing Kubernetes incidents for an AI agent runtime.
+
+Given an incident (OOMKilled, CrashLoopBackOff, etc.), produce:
+1. A brief diagnostic analysis (2-4 sentences).
+2. A proposed remediation action as JSON, after an "ACTION:" marker.
+
+Allowed actions: bump-memory, bump-cpu, restart-pod, rollout-restart, scale-replicas.
+
+Action JSON format:
+{"action":"<action>","params":{...},"generation":<unix-millis>,"source":"companion-claw"}
+
+If you cannot determine a safe action, omit the ACTION marker entirely. Never invent
+actions outside the allowlist.`
+
+// extractAction splits an LLM response into (analysis, action JSON).
+// Looks for "ACTION:" marker first, then ```json fenced block as fallback.
+// Returns ("", "") if no action found, with full content as analysis.
+func extractAction(content string) (string, string) {
+	// Try ACTION: marker first.
+	if idx := strings.Index(content, "ACTION:"); idx >= 0 {
+		analysis := strings.TrimSpace(content[:idx])
+		raw := strings.TrimSpace(content[idx+len("ACTION:"):])
+		raw = stripFences(raw)
+		if isValidJSONObject(raw) {
+			return analysis, raw
+		}
+		return analysis, ""
+	}
+
+	// Fallback: look for ```json ... ``` block.
+	if start := strings.Index(content, "```json"); start >= 0 {
+		rest := content[start+len("```json"):]
+		if end := strings.Index(rest, "```"); end >= 0 {
+			raw := strings.TrimSpace(rest[:end])
+			if isValidJSONObject(raw) {
+				analysis := strings.TrimSpace(content[:start])
+				return analysis, raw
+			}
+		}
+	}
+
+	return content, ""
+}
+
+// stripFences removes ```json / ``` markers from a string.
+func stripFences(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "```json")
+	s = strings.TrimPrefix(s, "```")
+	s = strings.TrimSuffix(s, "```")
+	return strings.TrimSpace(s)
+}
+
+// isValidJSONObject reports whether s parses as a JSON object.
+func isValidJSONObject(s string) bool {
+	var m map[string]any
+	return json.Unmarshal([]byte(s), &m) == nil
+}
+
+// truncate clips a string to maxLen characters, adding an ellipsis.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/cmd/claw4k8s/llm_client.go
+++ b/cmd/claw4k8s/llm_client.go
@@ -9,17 +9,23 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	controller "github.com/Prismer-AI/k8s4claw/internal/controller"
 )
 
 // HermesGatewayClient calls an OpenAI-compatible /v1/chat/completions endpoint.
 // Works with hermes-agent-rs hermes-gateway, Anthropic API (via gateway model
 // prefix), or any OpenAI-compatible provider.
+//
+// Concurrency: HermesGatewayClient is safe for concurrent use as long as
+// httpClient is initialized at construction time (see buildLLMClient in main.go).
 type HermesGatewayClient struct {
-	BaseURL string        // e.g. "http://hermes-gateway.default.svc.cluster.local:8080"
-	Model   string        // e.g. "anthropic/claude-sonnet-4-20250514"
-	APIKey  string        // optional; sent as Bearer token if non-empty
-	Timeout time.Duration // per-request timeout (default 60s)
+	BaseURL string // e.g. "http://hermes-gateway.default.svc.cluster.local:8080"
+	Model   string // e.g. "anthropic/claude-sonnet-4-20250514"
+	APIKey  string // optional; sent as Bearer token if non-empty
 
+	// httpClient must be set by the caller (e.g., buildLLMClient). Never
+	// initialized lazily inside Analyze to avoid data races under concurrent use.
 	httpClient *http.Client
 }
 
@@ -45,14 +51,14 @@ type chatCompletionResponse struct {
 
 // Analyze sends the prompt to the chat completions endpoint and parses the
 // response into (analysis, action). The action JSON is expected after an
-// "ACTION:" marker or inside a ```json fenced block.
+// "ACTION:" marker or inside a ```json fenced block. The action JSON is
+// validated against the operator's ops-intent whitelist (allowed actions only)
+// before being returned; invalid actions are discarded and ("analysis", "")
+// is returned with a nil error so the escalation falls through to
+// AwaitingApproval.
 func (c *HermesGatewayClient) Analyze(ctx context.Context, prompt string) (string, string, error) {
-	timeout := c.Timeout
-	if timeout <= 0 {
-		timeout = 60 * time.Second
-	}
 	if c.httpClient == nil {
-		c.httpClient = &http.Client{Timeout: timeout}
+		return "", "", fmt.Errorf("failed to call gateway: httpClient is nil (use buildLLMClient)")
 	}
 
 	reqBody := chatCompletionRequest{
@@ -64,13 +70,13 @@ func (c *HermesGatewayClient) Analyze(ctx context.Context, prompt string) (strin
 	}
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", "", fmt.Errorf("marshal request: %w", err)
+		return "", "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
 	url := strings.TrimRight(c.BaseURL, "/") + "/v1/chat/completions"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return "", "", fmt.Errorf("build request: %w", err)
+		return "", "", fmt.Errorf("failed to build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.APIKey != "" {
@@ -79,29 +85,62 @@ func (c *HermesGatewayClient) Analyze(ctx context.Context, prompt string) (strin
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", "", fmt.Errorf("call gateway: %w", err)
+		return "", "", fmt.Errorf("failed to call gateway: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", "", fmt.Errorf("read response: %w", err)
+		return "", "", fmt.Errorf("failed to read response: %w", err)
 	}
 	if resp.StatusCode >= 400 {
-		return "", "", fmt.Errorf("gateway returned %d: %s", resp.StatusCode, truncate(string(respBytes), 256))
+		// Note: response body is intentionally NOT included to avoid leaking
+		// API keys or other sensitive data that some proxies echo back.
+		return "", "", fmt.Errorf("failed gateway request: status %d", resp.StatusCode)
 	}
 
 	var parsed chatCompletionResponse
 	if err := json.Unmarshal(respBytes, &parsed); err != nil {
-		return "", "", fmt.Errorf("decode response: %w", err)
+		return "", "", fmt.Errorf("failed to decode response: %w", err)
 	}
 	if len(parsed.Choices) == 0 {
-		return "", "", fmt.Errorf("gateway returned no choices")
+		return "", "", fmt.Errorf("failed to parse response: no choices returned")
 	}
 
 	content := parsed.Choices[0].Message.Content
-	analysis, action := extractAction(content)
-	return analysis, action, nil
+	analysis, rawAction := extractAction(content)
+
+	// If the LLM proposed an action, validate it against the ops-intent schema
+	// and stamp a server-side generation counter (LLM clocks are unreliable).
+	if rawAction != "" {
+		validated, err := validateAndStampAction(rawAction)
+		if err != nil {
+			// Invalid action — discard so the escalation falls through to
+			// AwaitingApproval rather than writing garbage to ops-intent.
+			return analysis, "", nil
+		}
+		return analysis, validated, nil
+	}
+	return analysis, "", nil
+}
+
+// validateAndStampAction validates the raw LLM action JSON against the
+// ops-intent schema and overwrites the generation field with a server-side
+// timestamp (LLMs cannot produce reliable monotonic timestamps).
+func validateAndStampAction(raw string) (string, error) {
+	intent, err := controller.ValidateIntent(raw)
+	if err != nil {
+		return "", err
+	}
+	intent.Generation = time.Now().UnixMilli()
+	if intent.Source == "" {
+		intent.Source = "companion-claw"
+	}
+	out, err := json.Marshal(intent)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal validated intent: %w", err)
+	}
+	return string(out), nil
 }
 
 // companionSystemPrompt instructs the model to produce an analysis followed by
@@ -115,19 +154,27 @@ Given an incident (OOMKilled, CrashLoopBackOff, etc.), produce:
 Allowed actions: bump-memory, bump-cpu, restart-pod, rollout-restart, scale-replicas.
 
 Action JSON format:
-{"action":"<action>","params":{...},"generation":<unix-millis>,"source":"companion-claw"}
+{"action":"<action>","params":{...},"source":"companion-claw"}
 
-If you cannot determine a safe action, omit the ACTION marker entirely. Never invent
-actions outside the allowlist.`
+Required params:
+- bump-memory: {"target": "<size>"}        e.g. "768Mi", "2Gi"
+- bump-cpu:    {"target": "<cpu>"}         e.g. "500m", "2"
+- scale-replicas: {"replicas": "<count>"}  e.g. "3"
+- restart-pod, rollout-restart: no params required (use {})
+
+The "generation" field will be added by the operator — do not include it.
+
+If you cannot determine a safe action, omit the ACTION marker entirely. Never
+invent actions outside the allowlist.`
 
 // extractAction splits an LLM response into (analysis, action JSON).
 // Looks for "ACTION:" marker first, then ```json fenced block as fallback.
-// Returns ("", "") if no action found, with full content as analysis.
+// Returns (content, "") if no action found.
 func extractAction(content string) (string, string) {
 	// Try ACTION: marker first.
-	if idx := strings.Index(content, "ACTION:"); idx >= 0 {
-		analysis := strings.TrimSpace(content[:idx])
-		raw := strings.TrimSpace(content[idx+len("ACTION:"):])
+	if before, after, ok := strings.Cut(content, "ACTION:"); ok {
+		analysis := strings.TrimSpace(before)
+		raw := strings.TrimSpace(after)
 		raw = stripFences(raw)
 		if isValidJSONObject(raw) {
 			return analysis, raw
@@ -136,13 +183,11 @@ func extractAction(content string) (string, string) {
 	}
 
 	// Fallback: look for ```json ... ``` block.
-	if start := strings.Index(content, "```json"); start >= 0 {
-		rest := content[start+len("```json"):]
-		if end := strings.Index(rest, "```"); end >= 0 {
-			raw := strings.TrimSpace(rest[:end])
+	if before, after, ok := strings.Cut(content, "```json"); ok {
+		if inner, _, ok2 := strings.Cut(after, "```"); ok2 {
+			raw := strings.TrimSpace(inner)
 			if isValidJSONObject(raw) {
-				analysis := strings.TrimSpace(content[:start])
-				return analysis, raw
+				return strings.TrimSpace(before), raw
 			}
 		}
 	}
@@ -163,12 +208,4 @@ func stripFences(s string) string {
 func isValidJSONObject(s string) bool {
 	var m map[string]any
 	return json.Unmarshal([]byte(s), &m) == nil
-}
-
-// truncate clips a string to maxLen characters, adding an ellipsis.
-func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "..."
 }

--- a/cmd/claw4k8s/llm_client_test.go
+++ b/cmd/claw4k8s/llm_client_test.go
@@ -23,6 +23,17 @@ type fakeChatHandler struct {
 	gotAuth     string
 }
 
+// newTestClient returns a HermesGatewayClient with an eagerly-initialized
+// httpClient — mirrors how buildLLMClient constructs it in production.
+func newTestClient(baseURL, model, apiKey string, timeout time.Duration) *HermesGatewayClient {
+	return &HermesGatewayClient{
+		BaseURL:    baseURL,
+		Model:      model,
+		APIKey:     apiKey,
+		httpClient: &http.Client{Timeout: timeout},
+	}
+}
+
 func (h *fakeChatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.gotAuth = r.Header.Get("Authorization")
 
@@ -70,12 +81,7 @@ ACTION: {"action":"bump-memory","params":{"target":"768Mi"},"generation":1,"sour
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	client := &HermesGatewayClient{
-		BaseURL: srv.URL,
-		Model:   "anthropic/claude-sonnet-4",
-		APIKey:  "sk-test",
-		Timeout: 5 * time.Second,
-	}
+	client := newTestClient(srv.URL, "anthropic/claude-sonnet-4", "sk-test", 5*time.Second)
 
 	analysis, action, err := client.Analyze(context.Background(), "trigger: OOMKilled")
 	require.NoError(t, err)
@@ -98,7 +104,7 @@ func TestHermesGatewayClient_Analyze_NoActionInResponse(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 5 * time.Second}
+	client := newTestClient(srv.URL, "test", "x", 5*time.Second)
 	analysis, action, err := client.Analyze(context.Background(), "prompt")
 	require.NoError(t, err)
 	assert.Contains(t, analysis, "Manual review")
@@ -114,7 +120,7 @@ func TestHermesGatewayClient_Analyze_NoAPIKey(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", Timeout: 5 * time.Second}
+	client := newTestClient(srv.URL, "test", "", 5*time.Second)
 	_, _, err := client.Analyze(context.Background(), "prompt")
 	require.NoError(t, err)
 	assert.Empty(t, handler.gotAuth, "no API key → no Authorization header")
@@ -131,7 +137,7 @@ func TestHermesGatewayClient_Analyze_HTTPError(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 5 * time.Second}
+	client := newTestClient(srv.URL, "test", "x", 5*time.Second)
 	_, _, err := client.Analyze(context.Background(), "prompt")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "500")
@@ -144,7 +150,7 @@ func TestHermesGatewayClient_Analyze_MalformedJSON(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 5 * time.Second}
+	client := newTestClient(srv.URL, "test", "x", 5*time.Second)
 	_, _, err := client.Analyze(context.Background(), "prompt")
 	require.Error(t, err)
 }
@@ -157,7 +163,7 @@ func TestHermesGatewayClient_Analyze_EmptyChoices(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 5 * time.Second}
+	client := newTestClient(srv.URL, "test", "x", 5*time.Second)
 	_, _, err := client.Analyze(context.Background(), "prompt")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no choices")
@@ -171,7 +177,7 @@ func TestHermesGatewayClient_Analyze_ContextCancel(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 30 * time.Second}
+	client := newTestClient(srv.URL, "test", "x", 30*time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before sending
 
@@ -217,4 +223,66 @@ func TestExtractAction_InvalidJSON(t *testing.T) {
 	content := "ACTION: not a json object at all"
 	_, action := extractAction(content)
 	assert.Empty(t, action, "non-JSON action must be discarded")
+}
+
+// ---------------------------------------------------------------------------
+// validateAndStampAction — schema validation + server-stamped generation
+// ---------------------------------------------------------------------------
+
+func TestAnalyze_ValidatesActionAgainstAllowlist(t *testing.T) {
+	t.Parallel()
+	// LLM proposes an unknown action — must be discarded, escalation falls
+	// through to AwaitingApproval.
+	handler := &fakeChatHandler{
+		respContent: `analysis here
+
+ACTION: {"action":"delete-namespace","params":{},"source":"companion-claw"}`,
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	client := newTestClient(srv.URL, "test", "x", 5*time.Second)
+	analysis, action, err := client.Analyze(context.Background(), "prompt")
+	require.NoError(t, err)
+	assert.Contains(t, analysis, "analysis here")
+	assert.Empty(t, action, "unknown action must be discarded")
+}
+
+func TestAnalyze_StampsServerGeneration(t *testing.T) {
+	t.Parallel()
+	// LLM provides generation=1 (low/hallucinated). Server overwrites with
+	// time.Now().UnixMilli() so replay protection works correctly.
+	handler := &fakeChatHandler{
+		respContent: `analysis
+
+ACTION: {"action":"bump-memory","params":{"target":"768Mi"},"generation":1,"source":"companion-claw"}`,
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	before := time.Now().UnixMilli()
+	client := newTestClient(srv.URL, "test", "x", 5*time.Second)
+	_, action, err := client.Analyze(context.Background(), "prompt")
+	after := time.Now().UnixMilli()
+	require.NoError(t, err)
+	require.NotEmpty(t, action)
+
+	// Re-parse and check generation is server-stamped (within [before, after]).
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(action), &parsed))
+	gen, ok := parsed["generation"].(float64)
+	require.True(t, ok, "generation must be present")
+	assert.GreaterOrEqual(t, int64(gen), before, "generation should be >= before-call timestamp")
+	assert.LessOrEqual(t, int64(gen), after, "generation should be <= after-call timestamp")
+	assert.NotEqual(t, int64(1), int64(gen), "LLM-provided generation=1 must be overwritten")
+}
+
+func TestAnalyze_NilHTTPClient(t *testing.T) {
+	t.Parallel()
+	// Direct construction without buildLLMClient — should fail with clear error
+	// rather than racing on lazy init.
+	client := &HermesGatewayClient{BaseURL: "http://x", Model: "y"}
+	_, _, err := client.Analyze(context.Background(), "prompt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "httpClient is nil")
 }

--- a/cmd/claw4k8s/llm_client_test.go
+++ b/cmd/claw4k8s/llm_client_test.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeChatHandler returns a canned OpenAI-compatible response.
+type fakeChatHandler struct {
+	statusCode  int
+	respContent string
+	failBody    bool
+	gotPrompt   string
+	gotModel    string
+	gotAuth     string
+}
+
+func (h *fakeChatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.gotAuth = r.Header.Get("Authorization")
+
+	if r.URL.Path != "/v1/chat/completions" {
+		http.NotFound(w, r)
+		return
+	}
+
+	var req chatCompletionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	h.gotModel = req.Model
+	if len(req.Messages) > 0 {
+		h.gotPrompt = req.Messages[len(req.Messages)-1].Content
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if h.statusCode != 0 {
+		w.WriteHeader(h.statusCode)
+	}
+	if h.failBody {
+		_, _ = w.Write([]byte("not json"))
+		return
+	}
+	resp := chatCompletionResponse{
+		Choices: []chatChoice{{Message: chatMessage{Role: "assistant", Content: h.respContent}}},
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// ---------------------------------------------------------------------------
+// Analyze — happy path
+// ---------------------------------------------------------------------------
+
+func TestHermesGatewayClient_Analyze_ParsesAnalysisAndAction(t *testing.T) {
+	t.Parallel()
+
+	handler := &fakeChatHandler{
+		respContent: `Pod OOMKilled — memory limit too low for the workload.
+
+ACTION: {"action":"bump-memory","params":{"target":"768Mi"},"generation":1,"source":"companion-claw"}`,
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	client := &HermesGatewayClient{
+		BaseURL: srv.URL,
+		Model:   "anthropic/claude-sonnet-4",
+		APIKey:  "sk-test",
+		Timeout: 5 * time.Second,
+	}
+
+	analysis, action, err := client.Analyze(context.Background(), "trigger: OOMKilled")
+	require.NoError(t, err)
+	assert.Contains(t, analysis, "OOMKilled")
+	assert.Contains(t, action, "bump-memory")
+	assert.Contains(t, action, "768Mi")
+
+	// Verify request shape.
+	assert.Equal(t, "anthropic/claude-sonnet-4", handler.gotModel)
+	assert.Equal(t, "Bearer sk-test", handler.gotAuth)
+	assert.Contains(t, handler.gotPrompt, "OOMKilled")
+}
+
+func TestHermesGatewayClient_Analyze_NoActionInResponse(t *testing.T) {
+	t.Parallel()
+
+	handler := &fakeChatHandler{
+		respContent: "I cannot determine a safe remediation for this issue. Manual review recommended.",
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 5 * time.Second}
+	analysis, action, err := client.Analyze(context.Background(), "prompt")
+	require.NoError(t, err)
+	assert.Contains(t, analysis, "Manual review")
+	assert.Empty(t, action, "no ACTION marker → empty action")
+}
+
+func TestHermesGatewayClient_Analyze_NoAPIKey(t *testing.T) {
+	t.Parallel()
+	// Some local hermes-agent-rs deployments may not require an API key.
+	handler := &fakeChatHandler{
+		respContent: "ok",
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", Timeout: 5 * time.Second}
+	_, _, err := client.Analyze(context.Background(), "prompt")
+	require.NoError(t, err)
+	assert.Empty(t, handler.gotAuth, "no API key → no Authorization header")
+}
+
+// ---------------------------------------------------------------------------
+// Analyze — error paths
+// ---------------------------------------------------------------------------
+
+func TestHermesGatewayClient_Analyze_HTTPError(t *testing.T) {
+	t.Parallel()
+
+	handler := &fakeChatHandler{statusCode: http.StatusInternalServerError, respContent: "boom"}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 5 * time.Second}
+	_, _, err := client.Analyze(context.Background(), "prompt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestHermesGatewayClient_Analyze_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	handler := &fakeChatHandler{failBody: true}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 5 * time.Second}
+	_, _, err := client.Analyze(context.Background(), "prompt")
+	require.Error(t, err)
+}
+
+func TestHermesGatewayClient_Analyze_EmptyChoices(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"choices":[]}`))
+	}))
+	defer srv.Close()
+
+	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 5 * time.Second}
+	_, _, err := client.Analyze(context.Background(), "prompt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no choices")
+}
+
+func TestHermesGatewayClient_Analyze_ContextCancel(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // hang until client cancels
+	}))
+	defer srv.Close()
+
+	client := &HermesGatewayClient{BaseURL: srv.URL, Model: "test", APIKey: "x", Timeout: 30 * time.Second}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before sending
+
+	_, _, err := client.Analyze(ctx, "prompt")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// extractAction — parsing helpers
+// ---------------------------------------------------------------------------
+
+func TestExtractAction_StandardMarker(t *testing.T) {
+	t.Parallel()
+	content := `analysis text here
+
+ACTION: {"action":"bump-memory","params":{"target":"512Mi"},"generation":1,"source":"companion-claw"}`
+	analysis, action := extractAction(content)
+	assert.Contains(t, analysis, "analysis text")
+	assert.NotContains(t, analysis, "ACTION:")
+	assert.Contains(t, action, "bump-memory")
+}
+
+func TestExtractAction_FencedJSON(t *testing.T) {
+	t.Parallel()
+	content := "diagnosis here\n\n```json\n{\"action\":\"restart-pod\",\"params\":{},\"generation\":2,\"source\":\"companion-claw\"}\n```\n"
+	analysis, action := extractAction(content)
+	assert.Contains(t, analysis, "diagnosis")
+	assert.Contains(t, action, "restart-pod")
+	assert.False(t, strings.Contains(action, "```"), "fences should be stripped")
+}
+
+func TestExtractAction_NoAction(t *testing.T) {
+	t.Parallel()
+	content := "Just a description, no action proposed."
+	analysis, action := extractAction(content)
+	assert.Equal(t, content, analysis)
+	assert.Empty(t, action)
+}
+
+func TestExtractAction_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	// Marker present but the payload isn't valid JSON — return raw analysis, no action.
+	content := "ACTION: not a json object at all"
+	_, action := extractAction(content)
+	assert.Empty(t, action, "non-JSON action must be discarded")
+}

--- a/cmd/claw4k8s/main.go
+++ b/cmd/claw4k8s/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -46,8 +47,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: replace with real LLM client (Anthropic SDK).
-	llm := &noopLLMClient{}
+	// LLM client: use HermesGatewayClient if configured via env, else noop.
+	// Env vars:
+	//   LLM_GATEWAY_URL  — e.g. http://hermes-gateway.default.svc.cluster.local:8080
+	//   LLM_MODEL        — e.g. anthropic/claude-sonnet-4-20250514
+	//   LLM_API_KEY      — optional bearer token
+	llm := buildLLMClient(logger)
 
 	pipeline := &Pipeline{LLM: llm, MaxRetries: 3}
 
@@ -76,4 +81,26 @@ type noopLLMClient struct{}
 
 func (n *noopLLMClient) Analyze(_ context.Context, _ string) (string, string, error) {
 	return "", "", fmt.Errorf("LLM client not configured")
+}
+
+// buildLLMClient returns a HermesGatewayClient when LLM_GATEWAY_URL is set,
+// or a noopLLMClient otherwise. Falling back to noop allows the watcher to
+// run in environments without an LLM (escalations transition to
+// AwaitingApproval with a fallback analysis from the pipeline).
+func buildLLMClient(logger logr.Logger) LLMClient {
+	url := os.Getenv("LLM_GATEWAY_URL")
+	if url == "" {
+		logger.Info("LLM_GATEWAY_URL not set, using noop LLM client (fallback-only mode)")
+		return &noopLLMClient{}
+	}
+	model := os.Getenv("LLM_MODEL")
+	if model == "" {
+		model = "anthropic/claude-sonnet-4-20250514"
+	}
+	logger.Info("configured Hermes gateway LLM client", "url", url, "model", model)
+	return &HermesGatewayClient{
+		BaseURL: url,
+		Model:   model,
+		APIKey:  os.Getenv("LLM_API_KEY"),
+	}
 }

--- a/cmd/claw4k8s/main.go
+++ b/cmd/claw4k8s/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -76,31 +78,52 @@ func main() {
 	logger.Info("companion claw stopped")
 }
 
-// noopLLMClient is a placeholder LLM client that always returns a fallback.
+// noopLLMClient is a placeholder LLM client that returns immediately so the
+// pipeline's fallback path runs without burning the retry/backoff budget.
+// Used when no LLM gateway is configured (LLM_GATEWAY_URL unset).
 type noopLLMClient struct{}
 
 func (n *noopLLMClient) Analyze(_ context.Context, _ string) (string, string, error) {
-	return "", "", fmt.Errorf("LLM client not configured")
+	// Return empty result with no error so pipeline.analyze immediately
+	// reaches its fallback branch (no retries, no delays).
+	return "", "", nil
 }
 
-// buildLLMClient returns a HermesGatewayClient when LLM_GATEWAY_URL is set,
-// or a noopLLMClient otherwise. Falling back to noop allows the watcher to
-// run in environments without an LLM (escalations transition to
-// AwaitingApproval with a fallback analysis from the pipeline).
+// buildLLMClient returns a HermesGatewayClient when CLAW4K8S_LLM_GATEWAY_URL
+// is set, or a noopLLMClient otherwise. Env var names are aligned with
+// internal/runtime/k8sops.go (CLAW4K8S_LLM_*).
+//
+// Falling back to noop allows the watcher to run in environments without an
+// LLM — escalations transition to AwaitingApproval with a fallback analysis
+// from the pipeline (no retry delays).
 func buildLLMClient(logger logr.Logger) LLMClient {
-	url := os.Getenv("LLM_GATEWAY_URL")
+	url := firstEnv("CLAW4K8S_LLM_GATEWAY_URL", "LLM_GATEWAY_URL")
 	if url == "" {
-		logger.Info("LLM_GATEWAY_URL not set, using noop LLM client (fallback-only mode)")
+		logger.Info("LLM gateway URL not set, using noop LLM client (instant fallback mode)")
 		return &noopLLMClient{}
 	}
-	model := os.Getenv("LLM_MODEL")
+	model := firstEnv("CLAW4K8S_LLM_MODEL", "LLM_MODEL")
 	if model == "" {
 		model = "anthropic/claude-sonnet-4-20250514"
 	}
+	apiKey := firstEnv("CLAW4K8S_LLM_API_KEY", "LLM_API_KEY")
 	logger.Info("configured Hermes gateway LLM client", "url", url, "model", model)
 	return &HermesGatewayClient{
-		BaseURL: url,
-		Model:   model,
-		APIKey:  os.Getenv("LLM_API_KEY"),
+		BaseURL:    url,
+		Model:      model,
+		APIKey:     apiKey,
+		httpClient: &http.Client{Timeout: 60 * time.Second},
 	}
+}
+
+// firstEnv returns the first non-empty value among the given environment
+// variable names. The first name is the canonical key (CLAW4K8S_*); later
+// names are accepted for backward compatibility.
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary

Replace \`noopLLMClient\` in Companion Claw with a configurable HTTP client that calls any OpenAI-compatible \`/v1/chat/completions\` endpoint. Closes the claw4k8s self-healing loop end-to-end.

- Works with hermes-agent-rs hermes-gateway, Anthropic API, OpenRouter, or any compatible provider
- Env-configurable: \`LLM_GATEWAY_URL\`, \`LLM_MODEL\`, \`LLM_API_KEY\`
- Falls back to noop when \`LLM_GATEWAY_URL\` unset (deployments without LLM still work)
- Response parsing supports \`ACTION:\` marker and \`\`\`json fenced blocks
- Invalid action JSON is rejected (escalation goes to AwaitingApproval)
- 11 unit tests with httptest server

## Test plan

- [x] \`go test -race ./...\` all packages pass
- [x] \`go vet ./...\` clean
- [x] 11 new tests cover happy path, errors, parsing edge cases

🤖 Generated with [Claude Code](https://claude.ai/code)