### PR TITLE
feat(claw4k8s): support local development outside cluster

### DIFF
--- a/cmd/claw4k8s/.env.example
+++ b/cmd/claw4k8s/.env.example
@@ -1,0 +1,21 @@
+# claw4k8s local development env
+# Copy to .env and fill in your values:
+#   cp cmd/claw4k8s/.env.example cmd/claw4k8s/.env
+
+# LLM gateway — OpenAI-compatible /v1/chat/completions endpoint.
+# Examples:
+#   - new-api / one-api proxy:  https://your-newapi.example.com
+#   - direct Anthropic API:     https://api.anthropic.com (only if your gateway maps it)
+#   - local hermes-agent-rs:    http://localhost:8080
+CLAW4K8S_LLM_GATEWAY_URL=https://your-new-api.example.com
+
+# Bearer token sent as `Authorization: Bearer <key>`. Leave empty if your
+# gateway accepts anonymous requests.
+CLAW4K8S_LLM_API_KEY=sk-your-key-here
+
+# Model name as accepted by your gateway. Examples:
+#   anthropic/claude-sonnet-4-20250514, gpt-4o, claude-3-5-sonnet, ...
+CLAW4K8S_LLM_MODEL=claude-sonnet-4-20250514
+
+# K8s namespace the watcher polls for ClawOpsEscalation CRs.
+POD_NAMESPACE=default

--- a/cmd/claw4k8s/llm_client.go
+++ b/cmd/claw4k8s/llm_client.go
@@ -73,7 +73,16 @@ func (c *HermesGatewayClient) Analyze(ctx context.Context, prompt string) (strin
 		return "", "", fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := strings.TrimRight(c.BaseURL, "/") + "/v1/chat/completions"
+	// Build URL: tolerate BaseURL with or without `/v1` suffix.
+	// Examples accepted:
+	//   https://api.openai.com           → https://api.openai.com/v1/chat/completions
+	//   https://api.openai.com/v1        → https://api.openai.com/v1/chat/completions
+	//   http://newapi.example.com:3000/v1 → http://newapi.example.com:3000/v1/chat/completions
+	base := strings.TrimRight(c.BaseURL, "/")
+	url := base + "/v1/chat/completions"
+	if strings.HasSuffix(base, "/v1") {
+		url = base + "/chat/completions"
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return "", "", fmt.Errorf("failed to build request: %w", err)

--- a/cmd/claw4k8s/llm_client_test.go
+++ b/cmd/claw4k8s/llm_client_test.go
@@ -277,6 +277,40 @@ ACTION: {"action":"bump-memory","params":{"target":"768Mi"},"generation":1,"sour
 	assert.NotEqual(t, int64(1), int64(gen), "LLM-provided generation=1 must be overwritten")
 }
 
+// ---------------------------------------------------------------------------
+// BaseURL — accept with or without /v1 suffix
+// ---------------------------------------------------------------------------
+
+func TestAnalyze_BaseURLWithV1Suffix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		basePath string // path appended to test server URL to form BaseURL
+	}{
+		{"no /v1 suffix", ""},
+		{"/v1 suffix", "/v1"},
+		{"/v1/ trailing slash", "/v1/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var gotPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+			}))
+			defer srv.Close()
+
+			client := newTestClient(srv.URL+tt.basePath, "test", "x", 5*time.Second)
+			_, _, err := client.Analyze(context.Background(), "prompt")
+			require.NoError(t, err)
+			assert.Equal(t, "/v1/chat/completions", gotPath,
+				"path must always resolve to /v1/chat/completions regardless of BaseURL suffix")
+		})
+	}
+}
+
 func TestAnalyze_NilHTTPClient(t *testing.T) {
 	t.Parallel()
 	// Direct construction without buildLLMClient — should fail with clear error

--- a/cmd/claw4k8s/main.go
+++ b/cmd/claw4k8s/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -12,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -30,12 +30,17 @@ func main() {
 		namespace = "default"
 	}
 
-	// Build in-cluster K8s client.
+	// Build K8s client config: prefer in-cluster, fall back to KUBECONFIG /
+	// ~/.kube/config for local testing.
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
-		logger.Error(err, "failed to get in-cluster config (running outside cluster?)")
-		fmt.Fprintln(os.Stderr, "claw4k8s: requires in-cluster config; set KUBERNETES_SERVICE_HOST or use a kubeconfig")
-		os.Exit(1)
+		logger.Info("in-cluster config not available, trying kubeconfig", "err", err.Error())
+		cfg, err = ctrl.GetConfig()
+		if err != nil {
+			logger.Error(err, "failed to load any K8s config (no in-cluster, no kubeconfig)")
+			os.Exit(1)
+		}
+		logger.Info("using kubeconfig for K8s client (out-of-cluster mode)")
 	}
 
 	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {

--- a/scripts/run-claw4k8s-local.sh
+++ b/scripts/run-claw4k8s-local.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Run claw4k8s locally against the current kubeconfig context.
+# Loads env vars from cmd/claw4k8s/.env if present.
+#
+# Usage:
+#   1. cp cmd/claw4k8s/.env.example cmd/claw4k8s/.env
+#   2. edit cmd/claw4k8s/.env  (set CLAW4K8S_LLM_GATEWAY_URL, _API_KEY, _MODEL)
+#   3. ./scripts/run-claw4k8s-local.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/cmd/claw4k8s/.env"
+
+if [ -f "$ENV_FILE" ]; then
+    echo "loading env from $ENV_FILE"
+    # Parse line by line: skip comments / blanks / lines without `=`.
+    # Strip optional surrounding quotes and any whitespace around `=`.
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Trim leading whitespace.
+        line="${line#"${line%%[![:space:]]*}"}"
+        # Skip comments and blank lines.
+        case "$line" in
+            ''|'#'*) continue ;;
+        esac
+        # Must contain `=`.
+        case "$line" in
+            *=*) ;;
+            *) continue ;;
+        esac
+        key="${line%%=*}"
+        val="${line#*=}"
+        # Trim whitespace around key.
+        key="${key// /}"
+        # Trim leading whitespace from value.
+        val="${val#"${val%%[![:space:]]*}"}"
+        # Trim trailing whitespace from value.
+        val="${val%"${val##*[![:space:]]}"}"
+        # Strip optional surrounding quotes from value.
+        case "$val" in
+            \"*\") val="${val#\"}"; val="${val%\"}" ;;
+            \'*\') val="${val#\'}"; val="${val%\'}" ;;
+        esac
+        export "$key=$val"
+    done < "$ENV_FILE"
+else
+    echo "no .env at $ENV_FILE — using current shell env only"
+    echo "(copy cmd/claw4k8s/.env.example to cmd/claw4k8s/.env to populate)"
+fi
+
+# Build if missing or any source file is newer than the binary.
+NEEDS_BUILD=0
+if [ ! -x "$REPO_ROOT/bin/claw4k8s" ]; then
+    NEEDS_BUILD=1
+elif [ -n "$(find "$REPO_ROOT/cmd/claw4k8s" -name '*.go' -newer "$REPO_ROOT/bin/claw4k8s" 2>/dev/null | head -1)" ]; then
+    NEEDS_BUILD=1
+fi
+if [ "$NEEDS_BUILD" = "1" ]; then
+    echo "building bin/claw4k8s..."
+    (cd "$REPO_ROOT" && go build -o bin/claw4k8s ./cmd/claw4k8s)
+fi
+
+# Quick sanity check.
+if [ -z "${CLAW4K8S_LLM_GATEWAY_URL:-}" ]; then
+    echo "WARNING: CLAW4K8S_LLM_GATEWAY_URL is not set — running in noop fallback mode (no real LLM calls)"
+fi
+
+echo "kubeconfig context: $(kubectl config current-context 2>/dev/null || echo '<none>')"
+echo "starting claw4k8s..."
+exec "$REPO_ROOT/bin/claw4k8s"


### PR DESCRIPTION
## Summary

Three additions to make the Companion Claw binary testable against a real LLM gateway without deploying to a cluster.

1. **\`main.go\`** — fall back to \`ctrl.GetConfig()\` (KUBECONFIG / ~/.kube/config) when \`InClusterConfig\` fails. Was previously a hard exit.
2. **\`llm_client.go\`** — tolerate BaseURL with or without \`/v1\` suffix. new-api / one-api proxies typically expose \`https://host/v1\`, which would have produced \`/v1/v1/...\` 404. 3 new subtests cover no-suffix / /v1 / /v1/ trailing-slash.
3. **\`.env.example\` + \`scripts/run-claw4k8s-local.sh\`** — .env-driven local runner. Robust line-by-line parser (no \`source\` — handles \`:\` and other shell metachars). Rebuilds binary when any source file is newer.

## Verified end-to-end

- Real LLM (kimi-k2-turbo-preview via new-api): Pending → AwaitingApproval in 2s with valid \`bump-memory target=1Gi\` proposed action and server-stamped generation timestamp.
- Mock LLM returning \`delete-namespace\`: ValidateIntent correctly rejected, \`status.proposedAction\` empty, escalation falls through to AwaitingApproval for human review.

## Test plan

- [x] \`go test -race ./...\` all packages pass
- [x] \`go vet ./...\` clean
- [x] 3 new BaseURL subtests pass
- [x] Manual end-to-end on kind cluster

🤖 Generated with [Claude Code](https://claude.ai/code)