### PR TITLE
fix(hermesrs): make adapter + Dockerfile actually buildable and runnable

### DIFF
--- a/internal/runtime/hermesrs.go
+++ b/internal/runtime/hermesrs.go
@@ -31,7 +31,7 @@ func (a *HermesRSAdapter) runtimeSpec(_ *v1alpha1.Claw) *RuntimeSpec {
 	return &RuntimeSpec{
 		Image:     "ghcr.io/prismer-ai/hermes-agent-rs:latest",
 		Command:   []string{"/usr/local/bin/hermes"},
-		Args:      []string{"gateway", "run"},
+		Args:      []string{"gateway"},
 		Ports:     []corev1.ContainerPort{{Name: "gateway", ContainerPort: hermesRSGatewayPort, Protocol: corev1.ProtocolTCP}},
 		Resources: resources("250m", "512Mi", "2000m", "4Gi"),
 		Env: []corev1.EnvVar{

--- a/runtimes/hermesrs/Dockerfile
+++ b/runtimes/hermesrs/Dockerfile
@@ -20,7 +20,8 @@ ARG HERMES_REPO=
 ARG HERMES_REF=main
 
 # ---------- Builder ----------
-FROM rust:1.86-bookworm AS builder
+# rust 1.88+ required: hermes-agent-rs deps (home, time) need rustc >= 1.88.
+FROM rust:1.88-bookworm AS builder
 
 WORKDIR /workspace
 
@@ -68,4 +69,4 @@ ENV HERMES_HOME=/data \
     RUST_LOG=info
 
 ENTRYPOINT ["/usr/local/bin/hermes"]
-CMD ["gateway", "run"]
+CMD ["gateway"]

--- a/runtimes/hermesrs/README.md
+++ b/runtimes/hermesrs/README.md
@@ -9,10 +9,10 @@ The HermesRS adapter (see [internal/runtime/hermesrs.go](../../internal/runtime/
 expects:
 
 | Property | Value |
-|----------|-------|
+| --- | --- |
 | Binary path | `/usr/local/bin/hermes` |
-| Default command | `gateway run` |
-| Listen address | `0.0.0.0:8080` (configurable via `HERMES_GATEWAY_API_SERVER_BIND_ADDR`) |
+| Default command | `gateway` |
+| Listen address | `0.0.0.0:8080` (set in `config.yaml` under `gateway.api_server.bind_addr`) |
 | Health endpoint | `GET /health` |
 | Home directory | `/data` (`HERMES_HOME`) |
 | Workspace path | `/data/skills` |
@@ -38,6 +38,31 @@ git submodule or `cargo vendor`), then:
 docker build -f runtimes/hermesrs/Dockerfile \
   -t hermesrs:dev runtimes/hermesrs/
 ```
+
+## Configuration
+
+The binary requires a YAML config file at `$HERMES_HOME/config.yaml`
+(default: `/data/config.yaml`). Pure environment variables are NOT sufficient
+to enable the gateway; the YAML must explicitly enable `gateway.api_server`.
+
+A minimal example is at [config.example.yaml](config.example.yaml). To run
+locally with a Kimi-via-new-api proxy:
+
+```bash
+docker run -d --name hermesrs \
+  -e OPENAI_API_KEY="$YOUR_KEY" \
+  -v $(pwd)/runtimes/hermesrs/config.example.yaml:/data/config.yaml:ro \
+  -p 8080:8080 \
+  ghcr.io/prismer-ai/hermes-agent-rs:latest
+
+curl http://localhost:8080/health
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"openai/claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}'
+```
+
+When deployed via the HermesRS Claw adapter, the operator generates a ConfigMap
+from `spec.config` and mounts it at `/data/config.yaml`.
 
 ## CI / release
 

--- a/runtimes/hermesrs/config.example.yaml
+++ b/runtimes/hermesrs/config.example.yaml
@@ -1,0 +1,32 @@
+# Minimal hermes-agent-rs config for the API server gateway.
+#
+# Mount this file at $HERMES_HOME/config.yaml inside the Pod (default: /data/config.yaml).
+# In a Claw CR, use a ConfigMap reference via spec.config.
+#
+# Provider routing:
+#   - "openai/<model>"       → uses OPENAI_API_KEY (or HERMES_API_KEY fallback)
+#                              + base_url for OpenAI-compatible proxies (new-api,
+#                              one-api, OpenRouter, etc.)
+#   - "anthropic/<model>"    → uses ANTHROPIC_API_KEY
+#   - bare "<model>"         → defaults to OpenAI provider
+#
+# Override at runtime via env: OPENAI_BASE_URL, OPENAI_API_KEY, etc.
+
+model: openai/claude-sonnet-4-20250514
+
+# Optional: override provider base URL (for new-api / one-api / etc.)
+# base_url: https://your-newapi.example.com/v1
+
+gateway:
+  api_server:
+    bind_addr: "0.0.0.0:8080"
+    # Optional bearer token required on incoming requests.
+    # api_key: "${HERMES_API_KEY}"
+
+# Other knobs available — see hermes-agent-rs config.example.yaml upstream:
+#   max_iterations: 90
+#   temperature: 0.7
+#   approval:
+#     policy: ask
+#   signet:
+#     enabled: true


### PR DESCRIPTION
## Summary

While doing the first real build of hermes-agent-rs against the upstream repo, three integration bugs surfaced. Now verified end-to-end: build → run → \`/v1/chat/completions\` returns a real LLM response (~1.5s) via Kimi-k2 through a new-api proxy.

1. **Rust 1.86 base image too old** — upstream deps (\`home\`, \`time\`, \`time-core\`) require rustc ≥ 1.88. Bumped \`FROM rust:1.86-bookworm\` → \`1.88-bookworm\`.

2. **Wrong CMD/Args** — \`hermes-cli\` CLI accepts \`gateway\` (no subcommand). Updated Dockerfile CMD and \`HermesRSAdapter.RuntimeSpec.Args\`.

3. **Config path + format misunderstanding** — env vars alone don't enable the API server. Binary needs YAML config at \`\$HERMES_HOME/config.yaml\` (NOT \`\$HERMES_HOME/.hermes/config.yaml\`) with an explicit \`gateway.api_server\` section. Added \`config.example.yaml\` with provider routing notes (\`openai/\` → OPENAI_API_KEY + base_url; \`anthropic/\` → ANTHROPIC_API_KEY; bare → defaults to OpenAI) and a working \`docker run\` recipe in README.

## Test plan

- [x] \`go test -race ./...\` all 7 HermesRS adapter unit tests pass
- [x] \`docker build -f runtimes/hermesrs/Dockerfile --build-arg HERMES_REPO=https://github.com/willamhou/hermes-agent-rs.git .\` produces working image
- [x] Manual end-to-end: chat completion via Kimi-k2 model returned \`"Container orchestration platform automates deployment."\` in 1.x s

🤖 Generated with [Claude Code](https://claude.ai/code)