### PR TITLE
docs(runtimes): correct README inaccuracies + hermesclaw build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ The **Runtime** column shows the exact value to put in `spec.runtime` on a `Claw
 
 | `spec.runtime` | Language           | Upstream / Use Case                                                                                        | Gateway | Probe |
 | -------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- | ------- | ----- |
-| `openclaw`     | TypeScript/Node.js | Full-featured AI assistant platform (first-party)                                                          | 18900   | HTTP  |
-| `nanoclaw`     | TypeScript/Node.js | Lightweight secure personal assistant (first-party)                                                        | 19000   | TCP   |
-| `zeroclaw`     | Rust               | High-performance agent runtime (first-party)                                                               | 3000    | HTTP  |
-| `picoclaw`     | —                  | Ultra-minimal serverless agent (first-party)                                                               | 8080    | TCP   |
-| `ironclaw`     | Rust + WASM        | Security/privacy-focused AI assistant (first-party)                                                        | 3001    | HTTP  |
-| `hermesclaw`   | Python             | Runs [nousresearch/hermes-agent](https://github.com/nousresearch/hermes-agent) via a RuntimeAdapter        | 8642    | HTTP  |
-| `hermesrs`     | Rust               | Runs [hermes-agent-rs](https://github.com/nousresearch/hermes-agent-rs) — Rust-native variant of HermesClaw | 8080    | HTTP  |
+| `openclaw`     | Go                 | WebSocket AI gateway + Anthropic SDK (first-party, verified end-to-end)                                    | 18900   | HTTP  |
+| `nanoclaw`     | TypeScript/Node.js | Lightweight secure personal assistant (first-party, **adapter only — image not yet shipped**)              | 19000   | TCP   |
+| `zeroclaw`     | Rust               | High-performance agent runtime (first-party, **adapter only — image not yet shipped**)                     | 3000    | HTTP  |
+| `picoclaw`     | —                  | Ultra-minimal serverless agent (first-party, **adapter only — image not yet shipped**)                     | 8080    | TCP   |
+| `ironclaw`     | Rust + WASM        | Security/privacy-focused AI assistant (first-party, **adapter only — image not yet shipped**)              | 3001    | HTTP  |
+| `hermesclaw`   | Python             | NousResearch upstream Hermes Agent — build instructions in [runtimes/hermesclaw/](runtimes/hermesclaw/README.md) | 8642    | HTTP  |
+| `hermesrs`     | Rust               | Runs [hermes-agent-rs](https://github.com/willamhou/hermes-agent-rs) — Rust Hermes (verified end-to-end)   | 8080    | HTTP  |
 | `k8sops`       | Go                 | Companion Claw runtime used by [claw4k8s](docs/plans/2026-04-19-claw4k8s-design.md) for self-healing       | 8800    | HTTP  |
 | `custom`       | Any                | Bring your own runtime image                                                                               | —       | —     |
 

--- a/runtimes/hermesclaw/README.md
+++ b/runtimes/hermesclaw/README.md
@@ -1,0 +1,68 @@
+# HermesClaw runtime
+
+Bridge to [Nous Research's hermes-agent](https://github.com/NousResearch/hermes-agent),
+the upstream Python Hermes Agent. Used by the `runtime: hermesclaw` Claw adapter.
+
+## Status
+
+This runtime **does not ship a prebuilt image**. The HermesClaw adapter
+(see [internal/runtime/hermesclaw.go](../../internal/runtime/hermesclaw.go))
+points at `ghcr.io/nousresearch/hermes-agent:latest`, but as of this writing
+NousResearch has not published an image to GHCR. Users who want to deploy
+HermesClaw must build the image themselves and either push it under that
+default tag or override `spec.image` on the Claw CR.
+
+## Image contract
+
+The adapter expects the upstream Hermes Agent container to:
+
+| Property | Value |
+| --- | --- |
+| Listen address | `0.0.0.0:8642` (set via `API_SERVER_HOST` + `API_SERVER_PORT`) |
+| Health endpoint | `GET /health` |
+| Home directory | `/opt/data` (`HERMES_HOME`) |
+| Workspace path | `/opt/data/skills` |
+| API server enabled | `API_SERVER_ENABLED=true` |
+| Default model name | `hermes-agent` (`API_SERVER_MODEL_NAME`) |
+
+These are exactly the defaults of [NousResearch/hermes-agent's
+Dockerfile](https://github.com/NousResearch/hermes-agent/blob/main/Dockerfile),
+so the official upstream image (when one exists) drops in without changes.
+
+## Build from upstream
+
+```bash
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+docker build -t ghcr.io/nousresearch/hermes-agent:latest .
+# WARNING: ~30 min build, ~3GB image (Python + Node + Playwright Chromium).
+```
+
+To use a private registry instead:
+
+```bash
+docker tag ghcr.io/nousresearch/hermes-agent:latest your-registry/hermes-agent:v1
+docker push your-registry/hermes-agent:v1
+```
+
+Then set the image on your Claw CR:
+
+```yaml
+apiVersion: claw.prismer.ai/v1alpha1
+kind: Claw
+metadata:
+  name: my-hermes
+spec:
+  runtime: hermesclaw
+  image: your-registry/hermes-agent:v1   # override adapter default
+  credentials:
+    secretRef:
+      name: llm-keys
+```
+
+## Alternative: HermesRS
+
+For a faster, smaller, single-binary alternative, use the `hermesrs` runtime
+which wraps [hermes-agent-rs](https://github.com/willamhou/hermes-agent-rs) —
+the Rust port. Build is ~5 min, image is ~125MB, with managed-agents API
+support out of the box. See [runtimes/hermesrs/README.md](../hermesrs/README.md).


### PR DESCRIPTION
## Summary

Surfaced while verifying which runtimes actually run end-to-end — see prior PRs #21–#25.

**README runtime table corrections:**

- \`openclaw\`: TypeScript/Node.js → **Go** (uses \`github.com/anthropics/anthropic-sdk-go\`). Marked verified end-to-end (tested against real API, sub-2s response).
- \`hermesrs\`: link from \`nousresearch/hermes-agent-rs\` → **\`willamhou/hermes-agent-rs\`** (the actual upstream — Nous Research has no \`-rs\` repo). Marked verified end-to-end.
- \`nano/zero/pico/iron\`claw: marked **"adapter only — image not yet shipped"** to match reality. Codex's audit specifically called this out; README should say so.
- \`hermesclaw\`: shortened description, pointed to new build guide.

**New \`runtimes/hermesclaw/README.md\`:**

- Status block: NousResearch has not published an image to GHCR; users build themselves.
- Image contract table (port 8642, paths \`/opt/data\`, env \`API_SERVER_*\`) matching the adapter — verified the upstream Dockerfile produces these defaults.
- Build-from-upstream instructions with size/time warnings (~3GB, ~30 min).
- Cross-link to \`runtimes/hermesrs/\` as a faster alternative.

## Test plan

- [x] \`go vet ./...\` clean (no code changes)
- [x] Verified upstream URLs: \`nousresearch/hermes-agent\` exists ✓, \`nousresearch/hermes-agent-rs\` does NOT (404), \`willamhou/hermes-agent-rs\` exists ✓
- [x] Verified \`ghcr.io/nousresearch/hermes-agent:latest\` returns \`manifest unknown\` — confirms README needed the build-from-source warning

🤖 Generated with [Claude Code](https://claude.ai/code)