### PR TITLE
ci(release): publish hermes-agent-rs image on tagged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       go: ${{ steps.filter.outputs.go }}
       docs: ${{ steps.filter.outputs.docs }}
+      hermesrs: ${{ steps.filter.outputs.hermesrs }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -35,6 +36,9 @@ jobs:
             docs:
               - '**/*.md'
               - 'docs/**'
+            hermesrs:
+              - 'runtimes/hermesrs/**'
+              - 'internal/runtime/hermesrs.go'
 
   lint:
     needs: changes
@@ -130,6 +134,22 @@ jobs:
       - name: Build ${{ matrix.target.name }}
         run: docker build -f ${{ matrix.target.file }} ${{ matrix.target.context }}
 
+  # Separate slow build for hermes-agent-rs (Rust full compile ~10 min).
+  # Only runs when the Dockerfile or adapter changes — keeps PR feedback fast.
+  docker-build-hermesrs:
+    needs: changes
+    if: needs.changes.outputs.hermesrs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Build hermes-agent-rs
+        run: |
+          docker build -f runtimes/hermesrs/Dockerfile \
+            --build-arg HERMES_REPO=https://github.com/willamhou/hermes-agent-rs.git \
+            --build-arg HERMES_REF=main \
+            -t hermesrs:ci-smoke \
+            runtimes/hermesrs/
+
   govulncheck:
     needs: changes
     if: needs.changes.outputs.go == 'true'
@@ -202,7 +222,7 @@ jobs:
   # This lets docs-only PRs merge without admin override while still
   # failing fast on any real regression.
   ci-gate:
-    needs: [changes, lint, test, build, verify-codegen, docker-build, govulncheck, coverage-gate, dco]
+    needs: [changes, lint, test, build, verify-codegen, docker-build, docker-build-hermesrs, govulncheck, coverage-gate, dco]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,15 @@ jobs:
           - image: k8s4claw-openclaw
             dockerfile: runtimes/openclaw/Dockerfile
             context: runtimes/openclaw/
+          - image: hermes-agent-rs
+            dockerfile: runtimes/hermesrs/Dockerfile
+            context: runtimes/hermesrs/
+            # Rust cross-compile under QEMU is slow; amd64-only keeps the
+            # build under 30 min. ARM64 can be added in a follow-up.
+            platforms: linux/amd64
+            extra-build-args: |
+              HERMES_REPO=https://github.com/willamhou/hermes-agent-rs.git
+              HERMES_REF=main
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -94,11 +103,12 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platforms || 'linux/amd64,linux/arm64' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
+            ${{ matrix.extra-build-args }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 


### PR DESCRIPTION
## Summary

After PR #25 verified hermes-agent-rs builds and runs end-to-end, this wires the image into the release pipeline so users can \`docker pull ghcr.io/prismer-ai/hermes-agent-rs:vX.Y.Z\` without building locally.

**release.yml**
- New \`hermes-agent-rs\` matrix entry; clones upstream at build time via \`HERMES_REPO\` + \`HERMES_REF\` build-args (avoids vendoring ~80MB of Rust source).
- linux/amd64 only — Rust QEMU cross-compile to arm64 ~doubles build time. ARM64 can come later with native cross.
- Generalized \`build-args\` and \`platforms\` to accept per-entry overrides; existing entries unaffected.

**ci.yml**
- New \`docker-build-hermesrs\` job, gated on \`runtimes/hermesrs/**\` or \`internal/runtime/hermesrs.go\` changes. Keeps the ~10 min Rust build out of the hot PR path while still validating Dockerfile changes before merge.
- New \`hermesrs\` path filter in \`changes\` job.
- Added to \`ci-gate\` dependencies — correctly waits on relevant PRs, accepts \`skipped\` for unrelated PRs.

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"\` passes
- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"\` passes
- [x] Locally verified \`docker build -f runtimes/hermesrs/Dockerfile --build-arg HERMES_REPO=... .\` succeeds with the same args this workflow uses

🤖 Generated with [Claude Code](https://claude.ai/code)