### PR TITLE
chore(registry): clean up dead-code stubs from resolver

### DIFF
--- a/internal/registry/resolver.go
+++ b/internal/registry/resolver.go
@@ -263,16 +263,12 @@ func ImageForRuntime(runtime string) string {
 	switch runtime {
 	case "openclaw":
 		return "ghcr.io/prismer-ai/k8s4claw-openclaw"
-	case "nanoclaw":
-		return "ghcr.io/prismer-ai/k8s4claw-nanoclaw"
-	case "zeroclaw":
-		return "ghcr.io/prismer-ai/k8s4claw-zeroclaw"
-	case "picoclaw":
-		return "ghcr.io/prismer-ai/k8s4claw-picoclaw"
-	case "ironclaw":
-		return "ghcr.io/prismer-ai/k8s4claw-ironclaw"
 	case "hermesclaw":
 		return "ghcr.io/nousresearch/hermes-agent"
+	case "hermesrs":
+		return "ghcr.io/prismer-ai/hermes-agent-rs"
+	case "k8sops":
+		return "ghcr.io/prismer-ai/claw4k8s"
 	default:
 		return ""
 	}

--- a/internal/registry/resolver_test.go
+++ b/internal/registry/resolver_test.go
@@ -166,11 +166,9 @@ func TestImageForRuntime(t *testing.T) {
 		want    string
 	}{
 		{"openclaw", "ghcr.io/prismer-ai/k8s4claw-openclaw"},
-		{"nanoclaw", "ghcr.io/prismer-ai/k8s4claw-nanoclaw"},
-		{"zeroclaw", "ghcr.io/prismer-ai/k8s4claw-zeroclaw"},
-		{"picoclaw", "ghcr.io/prismer-ai/k8s4claw-picoclaw"},
-		{"ironclaw", "ghcr.io/prismer-ai/k8s4claw-ironclaw"},
 		{"hermesclaw", "ghcr.io/nousresearch/hermes-agent"},
+		{"hermesrs", "ghcr.io/prismer-ai/hermes-agent-rs"},
+		{"k8sops", "ghcr.io/prismer-ai/claw4k8s"},
 		{"unknown", ""},
 		{"", ""},
 	}


### PR DESCRIPTION
## Summary

Path C follow-up to #28 (delete 4 stub runtime adapters). The OCI registry
resolver still referenced the deleted `nanoclaw`, `zeroclaw`, `picoclaw`,
and `ironclaw` runtimes, and was missing entries for the surviving
`hermesrs` and `k8sops` runtimes.

- `ImageForRuntime`: drop 4 stub cases, add `hermesrs` + `k8sops` to
  match the registered adapter set (`openclaw`, `hermesclaw`, `hermesrs`,
  `k8sops`).
- `resolver_test.go`: matching test data update.

## Test plan

- [x] `go test -race ./internal/registry/...`
- [x] `go vet ./...`
- [ ] CI runs lint + tests on PR