### PR TITLE
feat(claw4k8s): multi-namespace watcher + Slack/Discord notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/
 /channel-webhook
 .claude/
 /claw-init
+/claw4k8s
 coverage.txt
 *.dll
 .DS_Store

--- a/cmd/claw4k8s/main.go
+++ b/cmd/claw4k8s/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -25,10 +26,12 @@ func main() {
 
 	logger.Info("companion claw starting")
 
-	namespace := os.Getenv("POD_NAMESPACE")
-	if namespace == "" {
-		namespace = "default"
-	}
+	// Namespace selection (priority: explicit list > singular pod ns > "default"):
+	//   CLAW4K8S_WATCH_NAMESPACES — comma-separated list. Empty value or
+	//                                "*" means cluster-wide (requires ClusterRole).
+	//   POD_NAMESPACE              — fallback singular namespace (set via
+	//                                downward API in the StatefulSet).
+	namespaces, scope := resolveWatchNamespaces(logger)
 
 	// Build K8s client config: prefer in-cluster, fall back to KUBECONFIG /
 	// ~/.kube/config for local testing.
@@ -63,17 +66,20 @@ func main() {
 
 	pipeline := &Pipeline{LLM: llm, MaxRetries: 3}
 
+	notifier := buildNotifier(logger)
+
 	watcher := &Watcher{
-		Client:    k8sClient,
-		Pipeline:  pipeline,
-		Namespace: namespace,
+		Client:     k8sClient,
+		Pipeline:   pipeline,
+		Notifier:   notifier,
+		Namespaces: namespaces,
 	}
 
 	// Graceful shutdown on SIGTERM/SIGINT.
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
 
-	logger.Info("starting escalation watcher", "namespace", namespace)
+	logger.Info("starting escalation watcher", "scope", scope)
 	if err := watcher.Run(ctx); err != nil {
 		logger.Error(err, "watcher exited with error")
 		cancel()
@@ -81,6 +87,56 @@ func main() {
 	}
 
 	logger.Info("companion claw stopped")
+}
+
+// resolveWatchNamespaces inspects env vars and returns the list of namespaces
+// the watcher should reconcile, plus a human-readable scope label for logs.
+//
+//	CLAW4K8S_WATCH_NAMESPACES="*"           → cluster-wide watch (requires ClusterRole)
+//	CLAW4K8S_WATCH_NAMESPACES="ns1,ns2"     → multi-namespace watch (Role per ns)
+//	CLAW4K8S_WATCH_NAMESPACES=""            → fall back to POD_NAMESPACE
+//	CLAW4K8S_WATCH_NAMESPACES unset         → check legacy CLAW4K8S_WATCH_NS,
+//	                                          then POD_NAMESPACE
+//	(none of the above set)                 → "default" namespace
+//
+// An empty value is treated as "fall back" rather than "cluster-wide" so a
+// container that always exports the canonical key (e.g. via Deployment env
+// list) never accidentally triggers a cluster-wide List call.
+//
+// The legacy CLAW4K8S_WATCH_NS key is consulted only when the canonical key
+// is *unset* (LookupEnv returns false). Once the canonical key is exported,
+// even as "", the legacy value is ignored to avoid stale leftovers from old
+// deployments overriding an explicit empty fallback.
+func resolveWatchNamespaces(logger logr.Logger) ([]string, string) {
+	var raw string
+	if v, ok := os.LookupEnv("CLAW4K8S_WATCH_NAMESPACES"); ok {
+		raw = strings.TrimSpace(v)
+	} else if v, ok := os.LookupEnv("CLAW4K8S_WATCH_NS"); ok {
+		raw = strings.TrimSpace(v)
+	}
+	if raw == "*" {
+		logger.Info("watching all namespaces (cluster-wide)")
+		return nil, "cluster-wide"
+	}
+	if raw != "" {
+		var ns []string
+		for part := range strings.SplitSeq(raw, ",") {
+			if p := strings.TrimSpace(part); p != "" {
+				ns = append(ns, p)
+			}
+		}
+		if len(ns) > 0 {
+			return ns, "namespaces=" + strings.Join(ns, ",")
+		}
+		// Whitespace-only payload (e.g. ", ,") — treat as if it had been empty.
+		logger.Info("CLAW4K8S_WATCH_NAMESPACES had no usable namespaces; falling back to POD_NAMESPACE")
+	}
+
+	podNS := os.Getenv("POD_NAMESPACE")
+	if podNS == "" {
+		podNS = "default"
+	}
+	return []string{podNS}, "namespace=" + podNS
 }
 
 // noopLLMClient is a placeholder LLM client that returns immediately so the
@@ -131,4 +187,35 @@ func firstEnv(keys ...string) string {
 		}
 	}
 	return ""
+}
+
+// buildNotifier returns a Notifier composed from the configured webhook URLs.
+// Env vars:
+//
+//	CLAW4K8S_SLACK_WEBHOOK_URL   — Slack incoming webhook URL
+//	CLAW4K8S_DISCORD_WEBHOOK_URL — Discord webhook URL
+//
+// If neither is set, returns a noopNotifier so the watcher runs unchanged.
+func buildNotifier(logger logr.Logger) Notifier {
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	var notifiers []Notifier
+
+	if url := os.Getenv("CLAW4K8S_SLACK_WEBHOOK_URL"); url != "" {
+		notifiers = append(notifiers, &SlackNotifier{WebhookURL: url, httpClient: httpClient})
+		logger.Info("configured Slack notifier")
+	}
+	if url := os.Getenv("CLAW4K8S_DISCORD_WEBHOOK_URL"); url != "" {
+		notifiers = append(notifiers, &DiscordNotifier{WebhookURL: url, httpClient: httpClient})
+		logger.Info("configured Discord notifier")
+	}
+
+	switch len(notifiers) {
+	case 0:
+		logger.Info("no notification webhooks configured (escalations will only surface in K8s API)")
+		return noopNotifier{}
+	case 1:
+		return notifiers[0]
+	default:
+		return &CompositeNotifier{Notifiers: notifiers}
+	}
 }

--- a/cmd/claw4k8s/main_test.go
+++ b/cmd/claw4k8s/main_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveWatchNamespaces(t *testing.T) {
+	// Not parallel — uses os.Setenv via t.Setenv.
+
+	tests := []struct {
+		name           string
+		watchEnv       string
+		podNamespace   string
+		wantNamespaces []string
+		wantScopeHas   string
+	}{
+		{
+			name:           "empty_env_falls_back_to_pod_namespace",
+			watchEnv:       "",
+			podNamespace:   "team-a",
+			wantNamespaces: []string{"team-a"},
+			wantScopeHas:   "namespace=team-a",
+		},
+		{
+			name:           "whitespace_env_falls_back_to_pod_namespace",
+			watchEnv:       "   ",
+			podNamespace:   "team-a",
+			wantNamespaces: []string{"team-a"},
+			wantScopeHas:   "namespace=team-a",
+		},
+		{
+			name:           "wildcard_means_cluster_wide",
+			watchEnv:       "*",
+			podNamespace:   "ignored",
+			wantNamespaces: nil,
+			wantScopeHas:   "cluster-wide",
+		},
+		{
+			name:           "single_namespace_in_env",
+			watchEnv:       "team-a",
+			podNamespace:   "ignored",
+			wantNamespaces: []string{"team-a"},
+			wantScopeHas:   "namespaces=team-a",
+		},
+		{
+			name:           "comma_separated_list",
+			watchEnv:       "team-a,team-b , team-c",
+			podNamespace:   "ignored",
+			wantNamespaces: []string{"team-a", "team-b", "team-c"},
+			wantScopeHas:   "namespaces=team-a,team-b,team-c",
+		},
+		{
+			name:           "whitespace_only_list_falls_back",
+			watchEnv:       ", ,",
+			podNamespace:   "team-a",
+			wantNamespaces: []string{"team-a"},
+			wantScopeHas:   "namespace=team-a",
+		},
+		{
+			name:           "no_env_no_pod_ns_defaults_to_default",
+			watchEnv:       "",
+			podNamespace:   "",
+			wantNamespaces: []string{"default"},
+			wantScopeHas:   "namespace=default",
+		},
+	}
+
+	logger := discardLogger()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CLAW4K8S_WATCH_NAMESPACES", tt.watchEnv)
+			t.Setenv("CLAW4K8S_WATCH_NS", "")
+			t.Setenv("POD_NAMESPACE", tt.podNamespace)
+
+			namespaces, scope := resolveWatchNamespaces(logger)
+			assert.Equal(t, tt.wantNamespaces, namespaces)
+			assert.Contains(t, scope, tt.wantScopeHas)
+		})
+	}
+}
+
+// TestResolveWatchNamespaces_LegacyEnvFallback verifies that the deprecated
+// CLAW4K8S_WATCH_NS env var is honored only when the canonical key is *unset*.
+// Once the canonical key is exported (even as ""), legacy is ignored.
+//
+// Cases use sentinel string values ("UNSET") to express "unset", "" to express
+// "set to empty", because t.Setenv only supports setting; explicit os.Unsetenv
+// is used for the unset case.
+func TestResolveWatchNamespaces_LegacyEnvFallback(t *testing.T) {
+	const unset = "__UNSET__"
+
+	tests := []struct {
+		name           string
+		canonical      string
+		legacy         string
+		podNamespace   string
+		wantNamespaces []string
+		wantScopeHas   string
+	}{
+		{
+			name:           "legacy_used_when_canonical_unset",
+			canonical:      unset,
+			legacy:         "team-legacy",
+			podNamespace:   "default",
+			wantNamespaces: []string{"team-legacy"},
+			wantScopeHas:   "namespaces=team-legacy",
+		},
+		{
+			name:           "legacy_ignored_when_canonical_set_empty",
+			canonical:      "",
+			legacy:         "team-legacy",
+			podNamespace:   "team-x",
+			wantNamespaces: []string{"team-x"},
+			wantScopeHas:   "namespace=team-x",
+		},
+		{
+			name:           "canonical_wins_when_both_set",
+			canonical:      "team-new",
+			legacy:         "team-legacy",
+			podNamespace:   "default",
+			wantNamespaces: []string{"team-new"},
+			wantScopeHas:   "namespaces=team-new",
+		},
+		{
+			name:           "legacy_wildcard_works_when_canonical_unset",
+			canonical:      unset,
+			legacy:         "*",
+			podNamespace:   "default",
+			wantNamespaces: nil,
+			wantScopeHas:   "cluster-wide",
+		},
+		{
+			name:           "both_unset_falls_back_to_pod_ns",
+			canonical:      unset,
+			legacy:         unset,
+			podNamespace:   "team-x",
+			wantNamespaces: []string{"team-x"},
+			wantScopeHas:   "namespace=team-x",
+		},
+	}
+
+	logger := discardLogger()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setOrUnset(t, "CLAW4K8S_WATCH_NAMESPACES", tt.canonical, unset)
+			setOrUnset(t, "CLAW4K8S_WATCH_NS", tt.legacy, unset)
+			t.Setenv("POD_NAMESPACE", tt.podNamespace)
+
+			namespaces, scope := resolveWatchNamespaces(logger)
+			assert.Equal(t, tt.wantNamespaces, namespaces)
+			assert.Contains(t, scope, tt.wantScopeHas)
+		})
+	}
+}
+
+// setOrUnset honors the unset-sentinel: if val == sentinel, the env var is
+// removed for the duration of the test; otherwise it is set to val. The
+// pre-test value is restored on test cleanup.
+func setOrUnset(t *testing.T, key, val, sentinel string) {
+	t.Helper()
+	prev, hadPrev := os.LookupEnv(key)
+	t.Cleanup(func() {
+		if hadPrev {
+			_ = os.Setenv(key, prev)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+	if val == sentinel {
+		_ = os.Unsetenv(key)
+	} else {
+		_ = os.Setenv(key, val)
+	}
+}

--- a/cmd/claw4k8s/notifier.go
+++ b/cmd/claw4k8s/notifier.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	v1alpha1 "github.com/Prismer-AI/k8s4claw/api/v1alpha1"
+)
+
+// Notifier sends a human-readable summary of an escalation transition to an
+// external channel (Slack, Discord, etc.).
+type Notifier interface {
+	// NotifyAwaitingApproval is called after an escalation reaches the
+	// AwaitingApproval phase. Implementations should make the call best-effort
+	// and respect ctx for cancellation/timeout.
+	NotifyAwaitingApproval(ctx context.Context, esc *v1alpha1.ClawOpsEscalation) error
+}
+
+// noopNotifier silently accepts notifications. Used when no channel is configured.
+type noopNotifier struct{}
+
+func (noopNotifier) NotifyAwaitingApproval(context.Context, *v1alpha1.ClawOpsEscalation) error {
+	return nil
+}
+
+// CompositeNotifier fans out to multiple notifiers. Errors are joined; a
+// partial failure does not prevent other notifiers from running.
+type CompositeNotifier struct {
+	Notifiers []Notifier
+}
+
+// NotifyAwaitingApproval invokes every child notifier and joins any errors.
+func (c *CompositeNotifier) NotifyAwaitingApproval(ctx context.Context, esc *v1alpha1.ClawOpsEscalation) error {
+	var errs []error
+	for _, n := range c.Notifiers {
+		if err := n.NotifyAwaitingApproval(ctx, esc); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// SlackNotifier posts a message to a Slack incoming webhook URL.
+type SlackNotifier struct {
+	WebhookURL string
+	httpClient *http.Client
+}
+
+type slackPayload struct {
+	Text string `json:"text"`
+}
+
+// NotifyAwaitingApproval posts a Slack-formatted summary to the configured webhook.
+func (s *SlackNotifier) NotifyAwaitingApproval(ctx context.Context, esc *v1alpha1.ClawOpsEscalation) error {
+	return postJSON(ctx, s.httpClient, s.WebhookURL, slackPayload{Text: formatSlackText(esc)})
+}
+
+// DiscordNotifier posts a message to a Discord webhook URL.
+type DiscordNotifier struct {
+	WebhookURL string
+	httpClient *http.Client
+}
+
+type discordPayload struct {
+	Content string `json:"content"`
+}
+
+// NotifyAwaitingApproval posts a Discord-formatted summary to the configured webhook.
+func (d *DiscordNotifier) NotifyAwaitingApproval(ctx context.Context, esc *v1alpha1.ClawOpsEscalation) error {
+	return postJSON(ctx, d.httpClient, d.WebhookURL, discordPayload{Content: formatDiscordText(esc)})
+}
+
+func formatSlackText(esc *v1alpha1.ClawOpsEscalation) string {
+	return formatNotification(esc, ":warning:", "*Claw escalation awaiting approval*", "*", "`")
+}
+
+func formatDiscordText(esc *v1alpha1.ClawOpsEscalation) string {
+	return formatNotification(esc, ":warning:", "**Claw escalation awaiting approval**", "**", "`")
+}
+
+// formatNotification builds the human-readable body for both Slack and Discord.
+// The bold/code markers are passed in because Slack uses *bold* while Discord
+// uses **bold** (the rest of the formatting is identical).
+//
+// When ProposedAction is empty (LLM fallback path) the message points the
+// on-call to manual inspection instead of `kubectl claw approve`, which the
+// CLI would reject with "empty proposedAction — nothing to approve".
+func formatNotification(esc *v1alpha1.ClawOpsEscalation, emoji, title, _ /*bold*/, code string) string {
+	analysis := esc.Status.Analysis
+	if analysis == "" {
+		analysis = "(no analysis)"
+	}
+	var proposedLine, actionLine string
+	if proposed := esc.Status.ProposedAction; proposed != "" {
+		proposedLine = fmt.Sprintf("Proposed action: %s%s%s\n", code, truncate(proposed, 240), code)
+		actionLine = fmt.Sprintf("Approve: %skubectl claw approve %s -n %s%s",
+			code, esc.Name, esc.Namespace, code)
+	} else {
+		actionLine = fmt.Sprintf(
+			"No proposed action — inspect manually: %skubectl describe clawopsescalation %s -n %s%s",
+			code, esc.Name, esc.Namespace, code)
+	}
+	return fmt.Sprintf(
+		"%s %s\n"+
+			"Claw: %s%s%s in %s%s%s\n"+
+			"Trigger: %s%s%s — %s (count=%d, severity=%s)\n"+
+			"Analysis: %s\n"+
+			"%s"+
+			"%s",
+		emoji, title,
+		code, esc.Spec.ClawRef.Name, code, code, esc.Namespace, code,
+		code, esc.Spec.Trigger.Type, code, esc.Spec.Trigger.Message,
+		esc.Spec.Trigger.Count, esc.Spec.Severity,
+		truncate(analysis, 480),
+		proposedLine,
+		actionLine,
+	)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+func postJSON(ctx context.Context, c *http.Client, url string, payload any) error {
+	if url == "" {
+		return errors.New("webhook URL is empty")
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if c == nil {
+		c = &http.Client{Timeout: 10 * time.Second}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Do(req) //nolint:gosec // URL is the operator's own webhook config, not user input
+	if err != nil {
+		return fmt.Errorf("post: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook returned %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/cmd/claw4k8s/notifier_test.go
+++ b/cmd/claw4k8s/notifier_test.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha1 "github.com/Prismer-AI/k8s4claw/api/v1alpha1"
+)
+
+func sampleEscalation() *v1alpha1.ClawOpsEscalation {
+	return &v1alpha1.ClawOpsEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-1", Namespace: "ai-agents"},
+		Spec: v1alpha1.ClawOpsEscalationSpec{
+			ClawRef:  corev1.LocalObjectReference{Name: "my-claw"},
+			Severity: v1alpha1.SeverityHigh,
+			Trigger: v1alpha1.TriggerInfo{
+				Type:    v1alpha1.TriggerOOMKilled,
+				Message: "Container OOMKilled",
+				Count:   3,
+			},
+		},
+		Status: v1alpha1.ClawOpsEscalationStatus{
+			Phase:          v1alpha1.EscalationPhaseAwaitingApproval,
+			Analysis:       "Memory leak in handler goroutine",
+			ProposedAction: `{"action":"bump-memory","params":{"target":"1Gi"}}`,
+		},
+	}
+}
+
+func TestSlackNotifier_PostsExpectedPayload(t *testing.T) {
+	t.Parallel()
+
+	var received atomic.Pointer[slackPayload]
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var p slackPayload
+		require.NoError(t, json.Unmarshal(body, &p))
+		received.Store(&p)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := &SlackNotifier{WebhookURL: srv.URL, httpClient: srv.Client()}
+	require.NoError(t, n.NotifyAwaitingApproval(context.Background(), sampleEscalation()))
+
+	got := received.Load()
+	require.NotNil(t, got, "server received no payload")
+	assert.Contains(t, got.Text, "my-claw")
+	assert.Contains(t, got.Text, "ai-agents")
+	assert.Contains(t, got.Text, string(v1alpha1.TriggerOOMKilled))
+	assert.Contains(t, got.Text, "Memory leak in handler goroutine")
+	assert.Contains(t, got.Text, "kubectl claw approve esc-1")
+}
+
+func TestDiscordNotifier_PostsExpectedPayload(t *testing.T) {
+	t.Parallel()
+
+	var received atomic.Pointer[discordPayload]
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var p discordPayload
+		require.NoError(t, json.Unmarshal(body, &p))
+		received.Store(&p)
+		w.WriteHeader(http.StatusNoContent) // Discord returns 204 on success
+	}))
+	defer srv.Close()
+
+	n := &DiscordNotifier{WebhookURL: srv.URL, httpClient: srv.Client()}
+	require.NoError(t, n.NotifyAwaitingApproval(context.Background(), sampleEscalation()))
+
+	got := received.Load()
+	require.NotNil(t, got, "server received no payload")
+	assert.Contains(t, got.Content, "my-claw")
+	assert.Contains(t, got.Content, "**Claw escalation awaiting approval**", "Discord uses **bold** markdown")
+	assert.Contains(t, got.Content, "kubectl claw approve esc-1")
+}
+
+func TestNotifier_NonOKStatusReturnsError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	slack := &SlackNotifier{WebhookURL: srv.URL, httpClient: srv.Client()}
+	err := slack.NotifyAwaitingApproval(context.Background(), sampleEscalation())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+
+	discord := &DiscordNotifier{WebhookURL: srv.URL, httpClient: srv.Client()}
+	err = discord.NotifyAwaitingApproval(context.Background(), sampleEscalation())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestNotifier_EmptyURLReturnsError(t *testing.T) {
+	t.Parallel()
+	slack := &SlackNotifier{}
+	err := slack.NotifyAwaitingApproval(context.Background(), sampleEscalation())
+	require.Error(t, err)
+}
+
+func TestNotifier_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Block until client cancels.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Second):
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	n := &SlackNotifier{WebhookURL: srv.URL, httpClient: srv.Client()}
+	err := n.NotifyAwaitingApproval(ctx, sampleEscalation())
+	require.Error(t, err, "expected error when context is cancelled")
+}
+
+// stubNotifier records calls and can be configured to return an error.
+type stubNotifier struct {
+	calls atomic.Int64
+	err   error
+}
+
+func (s *stubNotifier) NotifyAwaitingApproval(_ context.Context, _ *v1alpha1.ClawOpsEscalation) error {
+	s.calls.Add(1)
+	return s.err
+}
+
+func TestCompositeNotifier_FansOutAndJoinsErrors(t *testing.T) {
+	t.Parallel()
+
+	a := &stubNotifier{}
+	b := &stubNotifier{err: errors.New("b failed")}
+	c := &stubNotifier{err: errors.New("c failed")}
+
+	cn := &CompositeNotifier{Notifiers: []Notifier{a, b, c}}
+	err := cn.NotifyAwaitingApproval(context.Background(), sampleEscalation())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "b failed")
+	assert.Contains(t, err.Error(), "c failed")
+
+	assert.Equal(t, int64(1), a.calls.Load(), "a should be called even though b/c return errors")
+	assert.Equal(t, int64(1), b.calls.Load())
+	assert.Equal(t, int64(1), c.calls.Load())
+}
+
+func TestNoopNotifier(t *testing.T) {
+	t.Parallel()
+	n := noopNotifier{}
+	require.NoError(t, n.NotifyAwaitingApproval(context.Background(), sampleEscalation()))
+}
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "abc", truncate("abc", 5))
+	assert.Equal(t, "ab…", truncate("abcd", 2))
+	assert.Equal(t, "abcde", truncate("abcde", 5))
+}
+
+func TestFormatNotification_HandlesEmptyAnalysis(t *testing.T) {
+	t.Parallel()
+	esc := sampleEscalation()
+	esc.Status.Analysis = ""
+	esc.Status.ProposedAction = ""
+
+	text := formatSlackText(esc)
+	assert.Contains(t, text, "(no analysis)")
+	assert.NotContains(t, text, "Proposed action:", "no proposal line when ProposedAction is empty")
+	// kubectl-claw rejects approval when ProposedAction is empty, so the
+	// notification must NOT instruct the on-call to run that command.
+	assert.NotContains(t, text, "kubectl claw approve",
+		"approve hint must be suppressed when ProposedAction is empty")
+	assert.Contains(t, text, "kubectl describe clawopsescalation",
+		"empty-action notification should point at manual inspection instead")
+}
+
+func TestFormatNotification_IncludesApproveWhenProposalPresent(t *testing.T) {
+	t.Parallel()
+	esc := sampleEscalation() // sample has a non-empty ProposedAction.
+
+	text := formatSlackText(esc)
+	assert.Contains(t, text, "kubectl claw approve esc-1 -n ai-agents",
+		"approve hint must include the ns-qualified escalation name")
+	assert.NotContains(t, text, "kubectl describe clawopsescalation",
+		"manual-inspection fallback must not appear when a proposal exists")
+}
+
+func TestFormatNotification_TruncatesLongFields(t *testing.T) {
+	t.Parallel()
+	esc := sampleEscalation()
+	esc.Status.Analysis = strings.Repeat("x", 1000)
+
+	text := formatSlackText(esc)
+	// Should contain the truncation marker.
+	assert.True(t, strings.Contains(text, "…"), "expected ellipsis marker in truncated output")
+	// Should be shorter than the raw analysis.
+	assert.Less(t, len(text), 1000, "expected truncated output to fit comfortably under raw length")
+}
+
+// Sanity check that buildNotifier wiring respects env vars.
+func TestBuildNotifier_PicksUpEnv(t *testing.T) {
+	// Not parallel — uses os.Setenv.
+	t.Setenv("CLAW4K8S_SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/AAA/BBB/CCC")
+	t.Setenv("CLAW4K8S_DISCORD_WEBHOOK_URL", "https://discord.com/api/webhooks/123/abc")
+
+	logger := discardLogger()
+	n := buildNotifier(logger)
+
+	cn, ok := n.(*CompositeNotifier)
+	require.True(t, ok, "expected CompositeNotifier when both env vars set, got %T", n)
+	assert.Len(t, cn.Notifiers, 2)
+}
+
+func TestBuildNotifier_NoEnvReturnsNoop(t *testing.T) {
+	// Not parallel — uses os.Setenv (to clear).
+	t.Setenv("CLAW4K8S_SLACK_WEBHOOK_URL", "")
+	t.Setenv("CLAW4K8S_DISCORD_WEBHOOK_URL", "")
+
+	logger := discardLogger()
+	n := buildNotifier(logger)
+
+	_, ok := n.(noopNotifier)
+	require.True(t, ok, "expected noopNotifier when no env vars set, got %T", n)
+}
+
+// discardLogger returns a logger that drops all output (tests don't need it).
+func discardLogger() logr.Logger {
+	return logr.Discard()
+}

--- a/cmd/claw4k8s/watcher.go
+++ b/cmd/claw4k8s/watcher.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
+	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -15,17 +17,39 @@ const defaultPollInterval = 10 * time.Second
 
 // Watcher polls for Pending ClawOpsEscalation CRs and processes them
 // through the LLM analysis pipeline.
+//
+// Namespace selection:
+//
+//	Namespaces is empty            → cluster-wide watch (requires ClusterRole)
+//	Namespaces == ["foo"]          → single-namespace watch (requires Role in foo)
+//	Namespaces == ["foo", "bar"]   → multi-namespace watch (Role in each)
+//
+// For backwards compatibility, callers may set Namespace (singular); it is
+// merged into Namespaces on Run().
+//
+// NOTE: Multi-namespace and cluster-wide modes only widen the *consumer* of
+// escalations (this watcher). The producer side (operator's
+// ClawOpsController) still detects pod issues per-Claw within
+// claw.Namespace, so a single companion pod will only see escalations from
+// namespaces where Claw CRs already exist. Use these wider scopes when you
+// deploy claw4k8s as a plain Deployment to consolidate escalation review
+// across multiple Claw-bearing namespaces; do not expect them to extend
+// pod-level detection on their own.
 type Watcher struct {
-	Client    client.Client
-	Pipeline  *Pipeline
-	Namespace string
-	Interval  time.Duration
+	Client     client.Client
+	Pipeline   *Pipeline
+	Notifier   Notifier // optional; defaults to noopNotifier
+	Namespaces []string // namespaces to watch; empty = all
+	Namespace  string   // deprecated: use Namespaces. Kept for compat.
+	Interval   time.Duration
 }
 
 // Run starts the polling loop. Blocks until ctx is cancelled.
 func (w *Watcher) Run(ctx context.Context) error {
 	logger := log.FromContext(ctx).WithName("escalation-watcher")
-	logger.Info("starting escalation watcher", "namespace", w.Namespace, "interval", w.pollInterval())
+	w.normalizeNamespaces()
+	scope := w.scopeLabel()
+	logger.Info("starting escalation watcher", "scope", scope, "interval", w.pollInterval())
 
 	// Process once immediately on startup.
 	w.reconcilePending(ctx)
@@ -44,6 +68,24 @@ func (w *Watcher) Run(ctx context.Context) error {
 	}
 }
 
+// normalizeNamespaces folds the deprecated singular Namespace field into the
+// Namespaces slice. Idempotent.
+func (w *Watcher) normalizeNamespaces() {
+	if w.Namespace != "" {
+		if !slices.Contains(w.Namespaces, w.Namespace) {
+			w.Namespaces = append(w.Namespaces, w.Namespace)
+		}
+		w.Namespace = ""
+	}
+}
+
+func (w *Watcher) scopeLabel() string {
+	if len(w.Namespaces) == 0 {
+		return "cluster-wide"
+	}
+	return fmt.Sprintf("namespaces=%v", w.Namespaces)
+}
+
 func (w *Watcher) pollInterval() time.Duration {
 	if w.Interval > 0 {
 		return w.Interval
@@ -51,14 +93,38 @@ func (w *Watcher) pollInterval() time.Duration {
 	return defaultPollInterval
 }
 
-// reconcilePending lists all ClawOpsEscalation CRs in the namespace
-// and processes any that are in Pending phase. Returns the count of processed items.
+// reconcilePending lists ClawOpsEscalation CRs across the configured
+// namespaces (cluster-wide if Namespaces is empty) and processes any that
+// are in Pending phase. Returns the count of processed items.
 func (w *Watcher) reconcilePending(ctx context.Context) int {
 	logger := log.FromContext(ctx).WithName("escalation-watcher")
+	w.normalizeNamespaces()
 
+	processed := 0
+	if len(w.Namespaces) == 0 {
+		processed += w.reconcileNamespace(ctx, logger, "")
+	} else {
+		for _, ns := range w.Namespaces {
+			processed += w.reconcileNamespace(ctx, logger, ns)
+		}
+	}
+
+	if processed > 0 {
+		logger.Info("processed pending escalations", "count", processed)
+	}
+	return processed
+}
+
+// reconcileNamespace lists Pending escalations in a single namespace
+// (or cluster-wide if ns is empty) and processes them.
+func (w *Watcher) reconcileNamespace(ctx context.Context, logger logr.Logger, ns string) int {
 	var escList v1alpha1.ClawOpsEscalationList
-	if err := w.Client.List(ctx, &escList, client.InNamespace(w.Namespace)); err != nil {
-		logger.Error(err, "failed to list ClawOpsEscalations")
+	listOpts := []client.ListOption{}
+	if ns != "" {
+		listOpts = append(listOpts, client.InNamespace(ns))
+	}
+	if err := w.Client.List(ctx, &escList, listOpts...); err != nil {
+		logger.Error(err, "failed to list ClawOpsEscalations", "namespace", ns)
 		return 0
 	}
 
@@ -70,14 +136,10 @@ func (w *Watcher) reconcilePending(ctx context.Context) int {
 		}
 		if err := w.processEscalation(ctx, esc); err != nil {
 			logger.Error(err, "failed to process escalation",
-				"name", esc.Name, "claw", esc.Spec.ClawRef.Name)
+				"name", esc.Name, "namespace", esc.Namespace, "claw", esc.Spec.ClawRef.Name)
 			continue
 		}
 		processed++
-	}
-
-	if processed > 0 {
-		logger.Info("processed pending escalations", "count", processed)
 	}
 	return processed
 }
@@ -127,7 +189,26 @@ func (w *Watcher) processEscalation(ctx context.Context, esc *v1alpha1.ClawOpsEs
 	logger.Info("escalation analyzed",
 		"name", esc.Name, "phase", esc.Status.Phase,
 		"hasProposedAction", action != "")
+
+	// Notify external channels (Slack, Discord) — best-effort. A webhook
+	// failure must not block the escalation from being approved manually.
+	if n := w.notifier(); n != nil {
+		notifyCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		if nerr := n.NotifyAwaitingApproval(notifyCtx, esc); nerr != nil {
+			logger.Error(nerr, "failed to send escalation notification",
+				"name", esc.Name, "namespace", esc.Namespace)
+		}
+	}
 	return nil
+}
+
+// notifier returns the configured Notifier, or a noop if none is set.
+func (w *Watcher) notifier() Notifier {
+	if w.Notifier == nil {
+		return noopNotifier{}
+	}
+	return w.Notifier
 }
 
 // updatePhase sets the escalation phase via status subresource update.

--- a/cmd/claw4k8s/watcher_test.go
+++ b/cmd/claw4k8s/watcher_test.go
@@ -238,3 +238,217 @@ func TestReconcilePending_EmptyList(t *testing.T) {
 	processed := w.reconcilePending(context.Background())
 	assert.Equal(t, 0, processed)
 }
+
+// ---------------------------------------------------------------------------
+// Multi-namespace + scope handling
+// ---------------------------------------------------------------------------
+
+func TestReconcilePending_ClusterWide(t *testing.T) {
+	t.Parallel()
+	scheme := testScheme()
+
+	pendingNS1 := &v1alpha1.ClawOpsEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-1", Namespace: "team-a"},
+		Spec: v1alpha1.ClawOpsEscalationSpec{
+			ClawRef:  corev1.LocalObjectReference{Name: "claw-a"},
+			Severity: v1alpha1.SeverityHigh,
+			Trigger:  v1alpha1.TriggerInfo{Type: v1alpha1.TriggerOOMKilled, Count: 1},
+		},
+		Status: v1alpha1.ClawOpsEscalationStatus{Phase: v1alpha1.EscalationPhasePending},
+	}
+	pendingNS2 := &v1alpha1.ClawOpsEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-2", Namespace: "team-b"},
+		Spec: v1alpha1.ClawOpsEscalationSpec{
+			ClawRef:  corev1.LocalObjectReference{Name: "claw-b"},
+			Severity: v1alpha1.SeverityHigh,
+			Trigger:  v1alpha1.TriggerInfo{Type: v1alpha1.TriggerOOMKilled, Count: 1},
+		},
+		Status: v1alpha1.ClawOpsEscalationStatus{Phase: v1alpha1.EscalationPhasePending},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(pendingNS1, pendingNS2).
+		WithStatusSubresource(pendingNS1, pendingNS2).
+		Build()
+
+	llm := &mockLLMClient{analysis: "ok", action: `{"action":"bump-memory","params":{"target":"512Mi"},"generation":1,"source":"companion-claw"}`}
+	pipeline := &Pipeline{LLM: llm, MaxRetries: 1}
+
+	// Empty Namespaces == cluster-wide.
+	w := &Watcher{Client: fc, Pipeline: pipeline}
+
+	processed := w.reconcilePending(context.Background())
+	assert.Equal(t, 2, processed, "should process escalations from both namespaces")
+}
+
+func TestReconcilePending_MultiNamespace_OnlyListedAreReconciled(t *testing.T) {
+	t.Parallel()
+	scheme := testScheme()
+
+	inA := &v1alpha1.ClawOpsEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-a", Namespace: "team-a"},
+		Spec: v1alpha1.ClawOpsEscalationSpec{
+			ClawRef: corev1.LocalObjectReference{Name: "claw-a"}, Severity: v1alpha1.SeverityHigh,
+			Trigger: v1alpha1.TriggerInfo{Type: v1alpha1.TriggerOOMKilled, Count: 1},
+		},
+		Status: v1alpha1.ClawOpsEscalationStatus{Phase: v1alpha1.EscalationPhasePending},
+	}
+	inB := &v1alpha1.ClawOpsEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-b", Namespace: "team-b"},
+		Spec: v1alpha1.ClawOpsEscalationSpec{
+			ClawRef: corev1.LocalObjectReference{Name: "claw-b"}, Severity: v1alpha1.SeverityHigh,
+			Trigger: v1alpha1.TriggerInfo{Type: v1alpha1.TriggerOOMKilled, Count: 1},
+		},
+		Status: v1alpha1.ClawOpsEscalationStatus{Phase: v1alpha1.EscalationPhasePending},
+	}
+	inC := &v1alpha1.ClawOpsEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-c", Namespace: "team-c"},
+		Spec: v1alpha1.ClawOpsEscalationSpec{
+			ClawRef: corev1.LocalObjectReference{Name: "claw-c"}, Severity: v1alpha1.SeverityHigh,
+			Trigger: v1alpha1.TriggerInfo{Type: v1alpha1.TriggerOOMKilled, Count: 1},
+		},
+		Status: v1alpha1.ClawOpsEscalationStatus{Phase: v1alpha1.EscalationPhasePending},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(inA, inB, inC).
+		WithStatusSubresource(inA, inB, inC).
+		Build()
+
+	llm := &mockLLMClient{analysis: "ok", action: `{"action":"bump-memory","params":{"target":"512Mi"},"generation":1,"source":"companion-claw"}`}
+	pipeline := &Pipeline{LLM: llm, MaxRetries: 1}
+
+	// Watch only team-a and team-b, NOT team-c.
+	w := &Watcher{
+		Client:     fc,
+		Pipeline:   pipeline,
+		Namespaces: []string{"team-a", "team-b"},
+	}
+
+	processed := w.reconcilePending(context.Background())
+	assert.Equal(t, 2, processed, "should process esc-a and esc-b only")
+
+	// Verify team-c was NOT touched.
+	var untouched v1alpha1.ClawOpsEscalation
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{
+		Name: "esc-c", Namespace: "team-c",
+	}, &untouched))
+	assert.Equal(t, v1alpha1.EscalationPhasePending, untouched.Status.Phase, "team-c escalation must remain Pending")
+}
+
+func TestProcessEscalation_DispatchesNotificationOnAwaitingApproval(t *testing.T) {
+	t.Parallel()
+	scheme := testScheme()
+
+	esc := &v1alpha1.ClawOpsEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-notify", Namespace: "default"},
+		Spec: v1alpha1.ClawOpsEscalationSpec{
+			ClawRef:  corev1.LocalObjectReference{Name: "my-claw"},
+			Severity: v1alpha1.SeverityHigh,
+			Trigger:  v1alpha1.TriggerInfo{Type: v1alpha1.TriggerOOMKilled, Count: 1},
+		},
+		Status: v1alpha1.ClawOpsEscalationStatus{Phase: v1alpha1.EscalationPhasePending},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(esc).
+		WithStatusSubresource(esc).
+		Build()
+
+	llm := &mockLLMClient{
+		analysis: "ok",
+		action:   `{"action":"bump-memory","params":{"target":"512Mi"},"generation":1,"source":"companion-claw"}`,
+	}
+	stub := &stubNotifier{}
+	w := &Watcher{
+		Client:   fc,
+		Pipeline: &Pipeline{LLM: llm, MaxRetries: 1},
+		Notifier: stub,
+	}
+
+	require.NoError(t, w.processEscalation(context.Background(), esc))
+	assert.Equal(t, int64(1), stub.calls.Load(), "notifier must be called once after AwaitingApproval transition")
+}
+
+func TestProcessEscalation_NotifierErrorDoesNotFailReconcile(t *testing.T) {
+	t.Parallel()
+	scheme := testScheme()
+
+	esc := &v1alpha1.ClawOpsEscalation{
+		ObjectMeta: metav1.ObjectMeta{Name: "esc-notify-err", Namespace: "default"},
+		Spec: v1alpha1.ClawOpsEscalationSpec{
+			ClawRef:  corev1.LocalObjectReference{Name: "my-claw"},
+			Severity: v1alpha1.SeverityHigh,
+			Trigger:  v1alpha1.TriggerInfo{Type: v1alpha1.TriggerOOMKilled, Count: 1},
+		},
+		Status: v1alpha1.ClawOpsEscalationStatus{Phase: v1alpha1.EscalationPhasePending},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(esc).
+		WithStatusSubresource(esc).
+		Build()
+
+	llm := &mockLLMClient{analysis: "ok"}
+	w := &Watcher{
+		Client:   fc,
+		Pipeline: &Pipeline{LLM: llm, MaxRetries: 1},
+		// Notifier returns an error; reconcile must still succeed.
+		Notifier: &stubNotifier{err: assert.AnError},
+	}
+
+	require.NoError(t, w.processEscalation(context.Background(), esc))
+
+	var updated v1alpha1.ClawOpsEscalation
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{
+		Name: "esc-notify-err", Namespace: "default",
+	}, &updated))
+	assert.Equal(t, v1alpha1.EscalationPhaseAwaitingApproval, updated.Status.Phase,
+		"notification failure must not roll back the AwaitingApproval phase")
+}
+
+func TestNormalizeNamespaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		inSingular string
+		inPlural   []string
+		wantPlural []string
+	}{
+		{
+			name:       "singular only",
+			inSingular: "team-a",
+			wantPlural: []string{"team-a"},
+		},
+		{
+			name:       "plural only",
+			inPlural:   []string{"team-a", "team-b"},
+			wantPlural: []string{"team-a", "team-b"},
+		},
+		{
+			name:       "singular merged into plural",
+			inSingular: "team-c",
+			inPlural:   []string{"team-a", "team-b"},
+			wantPlural: []string{"team-a", "team-b", "team-c"},
+		},
+		{
+			name:       "singular already in plural is not duplicated",
+			inSingular: "team-a",
+			inPlural:   []string{"team-a", "team-b"},
+			wantPlural: []string{"team-a", "team-b"},
+		},
+		{
+			name:       "both empty",
+			wantPlural: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := &Watcher{Namespace: tt.inSingular, Namespaces: tt.inPlural}
+			w.normalizeNamespaces()
+			assert.Equal(t, tt.wantPlural, w.Namespaces)
+			assert.Empty(t, w.Namespace, "singular Namespace must be cleared after normalize")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two related companion-claw improvements, scoped to the consumer side (escalation watcher) only. Pod-level signal detection still happens per-Claw via the operator's \`ClawOpsController\` and is unchanged.

### Multi-namespace escalation watcher

\`Watcher\` now accepts a \`Namespaces []string\` field. \`main.go\` resolves it from \`CLAW4K8S_WATCH_NAMESPACES\` with these semantics:

| Value | Behavior |
|-------|----------|
| \`\"*\"\` | cluster-wide (requires ClusterRole) |
| \`\"a,b\"\` | multi-namespace (Role per ns) |
| \`\"\"\` (set, empty) | fall back to \`POD_NAMESPACE\` |
| (unset) | check legacy \`CLAW4K8S_WATCH_NS\`, then \`POD_NAMESPACE\` |

Uses \`LookupEnv\` (not \`Getenv\`) so an exported-but-empty canonical key cannot accidentally inherit a stale legacy value. Empty values map to \`POD_NAMESPACE\` rather than cluster-wide to avoid 403s when RBAC is namespace-scoped.

The deprecated singular \`Namespace\` field is preserved and folded into \`Namespaces\` for backward compatibility.

**Scope note:** Multi-namespace mode is useful when claw4k8s is deployed as a plain Deployment to consolidate escalation review across multiple Claw-bearing namespaces. The watcher docstring is explicit that this widens the *consumer* only — pod-level detection happens per-Claw via the operator and is not extended by this change. The Helm chart's existing per-namespace \`companion.rbac\` mode is unchanged.

### Slack / Discord notifications

New \`Notifier\` interface with three implementations:

- \`SlackNotifier\` — posts \`{text}\` JSON to a Slack incoming webhook
- \`DiscordNotifier\` — posts \`{content}\` JSON to a Discord webhook
- \`CompositeNotifier\` — fans out, joins errors

\`main.go\` wires \`CLAW4K8S_SLACK_WEBHOOK_URL\` / \`CLAW4K8S_DISCORD_WEBHOOK_URL\` into a composite (or single, or noop). The notifier is invoked best-effort after an escalation transitions to \`AwaitingApproval\`; webhook failures log but never roll back the phase.

The notification body suppresses the \`kubectl claw approve\` line when \`ProposedAction\` is empty (LLM-fallback path), pointing the on-call at \`kubectl describe clawopsescalation\` instead, since the CLI rejects approvals with empty proposedAction.

## Test plan

- [x] \`go test -race ./cmd/claw4k8s/...\` (24 tests, including new multi-ns + notifier suites)
- [x] \`go vet ./...\`
- [x] \`go test -race ./internal/runtime/...\` (unchanged adapters)
- [ ] CI runs lint + tests on PR

## Codex review history

This branch went through 6 rounds of \`codex review\` while iterating on a wider scope that also added \`clusterWide\` / \`centralServiceAccount\` Helm chart modes. Codex correctly flagged that the operator-side producer (\`ClawOpsController.collectSignals\`) is per-Claw and would not be widened by chart-only RBAC changes — making the chart-side modes a half-implemented feature. Per discussion, the chart changes were dropped from this PR. Operator-side multi-namespace detection is left for a follow-up that touches \`ClawOpsController\` directly.